### PR TITLE
[FEATURE] Pass cache headers

### DIFF
--- a/Classes/Middleware/MarkdownRequestMiddleware.php
+++ b/Classes/Middleware/MarkdownRequestMiddleware.php
@@ -30,20 +30,28 @@ use TYPO3\CMS\Core\Site\Entity\Site;
  */
 final readonly class MarkdownRequestMiddleware implements MiddlewareInterface
 {
-    public const MARKER_ATTRIBUTE = 'ai-bots-love-markdown.requested';
+    public const MARKDOWN_REQUESTED_ATTRIBUTE = 'ai-bots-love-markdown.requested';
+
+    /** @deprecated */
+    public const MARKER_ATTRIBUTE = self::MARKDOWN_REQUESTED_ATTRIBUTE;
+
+    public const CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE = 'ai-bots-love-markdown.contentNegotiationEnabled';
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (!$this->wantsMarkdown($request)) {
-            return $handler->handle($request);
-        }
-
         if (!$this->isEnabled($request)) {
             return $handler->handle($request);
         }
 
         // Mark the request for markdown conversion
-        $request = $request->withAttribute(self::MARKER_ATTRIBUTE, true);
+        $request = $request->withAttribute(self::CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE, true);
+
+        if (!$this->wantsMarkdown($request)) {
+            return $handler->handle($request);
+        }
+
+        // Mark the request for markdown conversion
+        $request = $request->withAttribute(self::MARKDOWN_REQUESTED_ATTRIBUTE, true);
 
         // Clean up the request: remove .md suffix and type parameter so normal page renders
         $request = $this->cleanRequest($request);

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -45,17 +45,22 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // Check if the early middleware marked this request for markdown conversion
-        if (!$request->getAttribute(MarkdownRequestMiddleware::MARKER_ATTRIBUTE)) {
-            return $handler->handle($request);
-        }
-
-        // Let the normal page render
         $response = $handler->handle($request);
 
         // Only process HTML responses
         $contentType = $response->getHeaderLine('Content-Type');
         if (!str_contains($contentType, 'text/html')) {
+            return $response;
+        }
+
+        if (!$request->getAttribute(MarkdownRequestMiddleware::CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE)) {
+            return $response;
+        }
+
+        $response = $response->withHeader('Vary', 'Accept');
+
+        // Check if the early middleware marked this request for markdown conversion
+        if (!$request->getAttribute(MarkdownRequestMiddleware::MARKDOWN_REQUESTED_ATTRIBUTE)) {
             return $response;
         }
 
@@ -75,14 +80,13 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $body->write($markdown);
         $body->rewind();
 
-        return new Response(
-            $body,
-            200,
-            [
-                'Content-Type' => 'text/markdown; charset=utf-8',
-                'X-Robots-Tag' => 'noindex',
-            ]
-        );
+        $response
+            ->withBody($body)
+            ->withStatus(200)
+            ->withHeader('Content-Type', 'text/markdown; charset=utf-8')
+            ->withHeader('X-Robots-Tag', 'noindex');
+
+        return $response;
     }
 
     private function convertToMarkdown(ServerRequestInterface $request, string $html): string


### PR DESCRIPTION
When using reverse proxies with this extension, cache headers aren't preserved. Also the usage of an Accept header must be signalled to the proxy via a Vary header.

If these headers aren't present, reverse proxies cache the markdown pages instead of html and supply those to the user.

This change marks requests within the middleware if content negotiation is enabled in addition to whether markdown is requested. That way the response middleware can add the Vary header even in text/html responses.