### PR TITLE
[FEATURE] Render fenced code blocks instead of indented text (BEXT-532)

### DIFF
--- a/Classes/Service/FencedCodeBlockConverter.php
+++ b/Classes/Service/FencedCodeBlockConverter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Service;
+
+use League\HTMLToMarkdown\Converter\ConverterInterface;
+use League\HTMLToMarkdown\ElementInterface;
+
+class FencedCodeBlockConverter implements ConverterInterface
+{
+    public function convert(ElementInterface $element): string
+    {
+        $innerHTML = $element->getChildrenAsString();
+
+        $language = '';
+        if (preg_match('/<code[^>]+class="[^"]*(?:language-|lang-)([a-zA-Z0-9_+#-]+)/i', $innerHTML, $matches)) {
+            $language = $matches[1];
+        }
+
+        $code = strip_tags($innerHTML);
+        $code = html_entity_decode($code, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $code = rtrim($code);
+
+        return "\n\n```{$language}\n{$code}\n```\n\n";
+    }
+
+    public function getSupportedTags(): array
+    {
+        return ['pre'];
+    }
+}

--- a/Classes/Service/HtmlToMarkdownService.php
+++ b/Classes/Service/HtmlToMarkdownService.php
@@ -27,6 +27,7 @@ class HtmlToMarkdownService
             'remove_nodes' => 'script style nav footer aside header form iframe',
         ]);
         $this->converter->getEnvironment()->addConverter(new TableConverter());
+        $this->converter->getEnvironment()->addConverter(new FencedCodeBlockConverter());
     }
 
     public function convert(string $html, string $baseUrl = ''): string


### PR DESCRIPTION
## Summary

- Add `FencedCodeBlockConverter` that overrides `<pre>` handling to emit triple-backtick fenced blocks instead of the default 4-space indented text
- Extracts language hint from inner `<code class="language-*"` or `lang-*` attributes
- Registers the converter in `HtmlToMarkdownService` after `TableConverter`

## Test plan

- [ ] Convert HTML with `<pre><code class="language-php">...</code></pre>` — expect ` ```php ` fenced block
- [ ] Convert HTML with `<pre><code>...</code></pre>` (no language) — expect ` ``` ` fenced block with no language tag
- [ ] Convert HTML without any `<pre>` blocks — no regression in output