### PR TITLE
Add Fluid marker-based content exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /Build/phpunit/.phpunit.*
 /.php-cs-fixer.cache
 /.Build/
+/vendor/
+/public/
+/var/

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+    bootstrap="../../vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>../../Tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <env name="TYPO3_CONTEXT" value="Testing"/>
+    </php>
+</phpunit>

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -37,6 +37,11 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
 {
     private const MARKDOWN_LINK_PATTERN = '/<link[^>]+rel=["\']alternate["\'][^>]+type=["\']text\/markdown["\'][^>]*>/i';
 
+    private const MARKER_START = '<!-- markdown-start -->';
+    private const MARKER_END = '<!-- markdown-end -->';
+    private const EXCLUDE_START = '<!-- markdown-exclude-start -->';
+    private const EXCLUDE_END = '<!-- markdown-exclude-end -->';
+
     public function __construct(
         private HtmlToMarkdownService $htmlToMarkdownService,
         private MetadataService $metadataService,
@@ -99,9 +104,18 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         // Get base URL for making relative URLs absolute
         $site = $request->getAttribute('site');
         $baseUrl = $site instanceof Site ? rtrim((string)$site->getBase(), '/') : '';
+        $removeElements = $site instanceof Site
+            ? (string)$site->getSettings()->get('ai_bots_love_markdown.removeElements', HtmlToMarkdownService::DEFAULT_REMOVE_ELEMENTS)
+            : null;
 
-        // Extract main content (prefer <main>, fallback to <body>)
+        // Extract main content (prefer markers, then <main>, fallback to <body>)
         $content = $this->extractMainContent($html);
+
+        // Drop any regions wrapped in <!-- markdown-exclude-start/end --> markers
+        $content = $this->removeExcludedSections($content);
+
+        // Defense-in-depth: strip residual markers before converter sees the HTML
+        $content = $this->stripMarkers($content);
 
         // Generate front matter from meta tags (with page record as fallback)
         $frontMatter = $this->metadataService->generateFrontMatter($html, $pageRecord, $fallbackUrl);
@@ -110,7 +124,7 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $pageTitle = $this->extractPageTitle($html, $pageRecord);
 
         // Convert HTML to Markdown
-        $markdownContent = $pageTitle . $this->htmlToMarkdownService->convert($content, $baseUrl);
+        $markdownContent = $pageTitle . $this->htmlToMarkdownService->convert($content, $baseUrl, $removeElements);
 
         // Dispatch event to allow modification of the markdown output
         $event = $this->eventDispatcher->dispatch(
@@ -151,17 +165,100 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
 
     private function extractMainContent(string $html): string
     {
-        // Try to extract <main> content first
+        // Priority 1: explicit content region between markdown-start/end markers
+        $markerContent = $this->extractBetweenMarkers($html);
+        if ($markerContent !== null) {
+            return $markerContent;
+        }
+
+        // Priority 2: <main> content
         if (preg_match('/<main[^>]*>(.*?)<\/main>/is', $html, $matches)) {
             return $matches[1];
         }
 
-        // Fallback to <body> content
+        // Priority 3: <body> content
         if (preg_match('/<body[^>]*>(.*?)<\/body>/is', $html, $matches)) {
             return $matches[1];
         }
 
         // Last resort: return the whole HTML
         return $html;
+    }
+
+    private function extractBetweenMarkers(string $html): ?string
+    {
+        $startPos = strpos($html, self::MARKER_START);
+        $endPos = strpos($html, self::MARKER_END);
+
+        if ($startPos === false || $endPos === false || $endPos <= $startPos) {
+            return null;
+        }
+
+        $contentStart = $startPos + strlen(self::MARKER_START);
+        return substr($html, $contentStart, $endPos - $contentStart);
+    }
+
+    /**
+     * Remove regions wrapped in <!-- markdown-exclude-start --> ... <!-- markdown-exclude-end -->.
+     * Depth-aware: nested exclude regions are handled correctly. Defensive against
+     * incomplete markers (missing end / end-before-start: nothing is removed).
+     */
+    private function removeExcludedSections(string $html): string
+    {
+        $result = $html;
+        $iterations = 0;
+        $maxIterations = 100;
+
+        while ($iterations < $maxIterations) {
+            $startPos = strpos($result, self::EXCLUDE_START);
+            if ($startPos === false) {
+                break;
+            }
+
+            $depth = 1;
+            $searchOffset = $startPos + strlen(self::EXCLUDE_START);
+            $endPos = false;
+
+            while ($depth > 0) {
+                $nextStart = strpos($result, self::EXCLUDE_START, $searchOffset);
+                $nextEnd = strpos($result, self::EXCLUDE_END, $searchOffset);
+
+                if ($nextEnd === false) {
+                    break 2;
+                }
+
+                if ($nextStart !== false && $nextStart < $nextEnd) {
+                    $depth++;
+                    $searchOffset = $nextStart + strlen(self::EXCLUDE_START);
+                } else {
+                    $depth--;
+                    if ($depth === 0) {
+                        $endPos = $nextEnd;
+                    }
+                    $searchOffset = $nextEnd + strlen(self::EXCLUDE_END);
+                }
+            }
+
+            if ($endPos === false) {
+                break;
+            }
+
+            $before = substr($result, 0, $startPos);
+            $after = substr($result, $endPos + strlen(self::EXCLUDE_END));
+            $result = $before . $after;
+
+            $iterations++;
+        }
+
+        return $result;
+    }
+
+    private function stripMarkers(string $html): string
+    {
+        return str_replace(
+            [self::MARKER_START, self::MARKER_END, self::EXCLUDE_START, self::EXCLUDE_END],
+            '',
+            $html
+        );
     }
 }

--- a/Classes/Middleware/StripMarkdownMarkersMiddleware.php
+++ b/Classes/Middleware/StripMarkdownMarkersMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Stream;
+
+/**
+ * Strips markdown extraction markers from frontend HTML responses.
+ *
+ * Markers are emitted by the bundled Fluid partials (MarkdownInclude /
+ * MarkdownExclude) and end up cached together with the page body. They must
+ * never be visible to human visitors, so this middleware removes them from
+ * every text/html response.
+ *
+ * Markdown responses (Content-Type: text/markdown) already have markers
+ * stripped during conversion in MarkdownResponseMiddleware and are skipped
+ * by the content-type check below.
+ */
+final class StripMarkdownMarkersMiddleware implements MiddlewareInterface
+{
+    private const MARKERS = [
+        '<!-- markdown-start -->',
+        '<!-- markdown-end -->',
+        '<!-- markdown-exclude-start -->',
+        '<!-- markdown-exclude-end -->',
+    ];
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        $contentType = $response->getHeaderLine('Content-Type');
+        if (!str_contains($contentType, 'text/html')) {
+            return $response;
+        }
+
+        $body = (string)$response->getBody();
+
+        if (!str_contains($body, '<!-- markdown-')) {
+            return $response;
+        }
+
+        $body = str_replace(self::MARKERS, '', $body);
+
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        return $response->withBody($stream);
+    }
+}

--- a/Classes/Service/HtmlToMarkdownService.php
+++ b/Classes/Service/HtmlToMarkdownService.php
@@ -17,51 +17,62 @@ use League\HTMLToMarkdown\HtmlConverter;
 
 class HtmlToMarkdownService
 {
-    private HtmlConverter $converter;
+    /**
+     * Default tags stripped from the markdown output. <header> is intentionally
+     * NOT in this list: an article-level <header> often contains the page H1
+     * and should reach the markdown output. Page-level <header> regions can be
+     * excluded via the MarkdownExclude partial (or by selecting <main> /
+     * markdown-start markers that exclude the page header by structure).
+     */
+    public const DEFAULT_REMOVE_ELEMENTS = 'script style nav footer aside form iframe noscript';
 
-    public function __construct()
+    public function convert(string $html, string $baseUrl = '', ?string $removeElements = null): string
     {
-        $this->converter = new HtmlConverter([
-            'strip_tags' => true,
-            'hard_break' => true,
-            'remove_nodes' => 'script style nav footer aside header form iframe',
-        ]);
-        $this->converter->getEnvironment()->addConverter(new TableConverter());
-    }
+        $elements = $this->parseElementList($removeElements ?? self::DEFAULT_REMOVE_ELEMENTS);
 
-    public function convert(string $html, string $baseUrl = ''): string
-    {
-        // Remove navigation, footer, aside elements
-        $html = $this->removeNonContentElements($html);
+        $html = $this->removeNonContentElements($html, $elements);
 
-        // Make image URLs absolute
         if ($baseUrl !== '') {
             $html = $this->makeUrlsAbsolute($html, $baseUrl);
         }
 
-        $markdown = $this->converter->convert($html);
+        $markdown = $this->buildConverter($elements)->convert($html);
 
-        // Clean up excessive whitespace
-        $markdown = $this->cleanupMarkdown($markdown);
-
-        return $markdown;
+        return $this->cleanupMarkdown($markdown);
     }
 
-    private function removeNonContentElements(string $html): string
+    private function buildConverter(array $elements): HtmlConverter
     {
-        // Remove elements that typically don't contain main content
-        $patterns = [
-            '/<nav\b[^>]*>.*?<\/nav>/is',
-            '/<footer\b[^>]*>.*?<\/footer>/is',
-            '/<aside\b[^>]*>.*?<\/aside>/is',
-            '/<header\b[^>]*>.*?<\/header>/is',
-            '/<form\b[^>]*>.*?<\/form>/is',
-            '/<script\b[^>]*>.*?<\/script>/is',
-            '/<style\b[^>]*>.*?<\/style>/is',
-            '/<iframe\b[^>]*>.*?<\/iframe>/is',
-            '/<noscript\b[^>]*>.*?<\/noscript>/is',
-        ];
+        $converter = new HtmlConverter([
+            'strip_tags' => true,
+            'hard_break' => true,
+            'remove_nodes' => implode(' ', $elements),
+        ]);
+        $converter->getEnvironment()->addConverter(new TableConverter());
+        return $converter;
+    }
 
+    /**
+     * @return string[]
+     */
+    private function parseElementList(string $list): array
+    {
+        $elements = preg_split('/\s+/', trim($list)) ?: [];
+        return array_values(array_filter($elements, static fn(string $tag) => $tag !== ''));
+    }
+
+    /**
+     * @param string[] $elements
+     */
+    private function removeNonContentElements(string $html, array $elements): string
+    {
+        if ($elements === []) {
+            return $html;
+        }
+        $patterns = array_map(
+            static fn(string $tag) => '/<' . preg_quote($tag, '/') . '\b[^>]*>.*?<\/' . preg_quote($tag, '/') . '>/is',
+            $elements,
+        );
         return preg_replace($patterns, '', $html) ?? $html;
     }
 

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -22,5 +22,12 @@ return [
                 'typo3/cms-frontend/content-length-headers',
             ],
         ],
+        // Strip markdown markers from HTML responses for human visitors
+        'b13/ai-bots-love-markdown/strip-markers' => [
+            'target' => \B13\AiBotsLoveMarkdown\Middleware\StripMarkdownMarkersMiddleware::class,
+            'after' => [
+                'typo3/cms-frontend/content-length-headers',
+            ],
+        ],
     ],
 ];

--- a/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
+++ b/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
@@ -7,3 +7,7 @@ settings:
     type: bool
     default: true
     label: 'Add <link rel="alternate"> tag for Markdown discovery'
+  ai_bots_love_markdown.removeElements:
+    type: string
+    default: 'script style nav footer aside form iframe noscript'
+    label: 'Space-separated HTML tags to strip from markdown output'

--- a/Configuration/Sets/ai_bots_love_markdown/setup.typoscript
+++ b/Configuration/Sets/ai_bots_love_markdown/setup.typoscript
@@ -12,3 +12,8 @@ page.headerData.1736000 {
     }
     wrap = <link rel="alternate" type="text/markdown" href="|" title="Markdown version" />
 }
+
+# Make MarkdownInclude / MarkdownExclude partials available to integrators
+# without requiring manual partialRootPaths configuration in their site set.
+lib.contentElement.partialRootPaths.1736001 = EXT:ai_bots_love_markdown/Resources/Private/Partials/
+page.10.partialRootPaths.1736001 = EXT:ai_bots_love_markdown/Resources/Private/Partials/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The extension provides two settings that can be configured per site (both enable
 |---------|---------|-------------|
 | `ai_bots_love_markdown.enableContentNegotiation` | `true` | Enable content negotiation via `Accept: text/markdown` header |
 | `ai_bots_love_markdown.enableDiscoveryTag` | `true` | Add `<link rel="alternate">` tag to HTML pages for Markdown discovery |
+| `ai_bots_love_markdown.removeElements` | `script style nav footer aside form iframe noscript` | Space-separated HTML tags stripped from the markdown output. `<header>` is intentionally not included — article-level `<header>` regions often contain the page H1 |
 
 To override these settings, add them to your site's `settings.yaml`:
 
@@ -43,6 +44,7 @@ To override these settings, add them to your site's `settings.yaml`:
 ai_bots_love_markdown:
   enableContentNegotiation: true
   enableDiscoveryTag: false
+  removeElements: 'script style nav footer aside form iframe noscript header'
 ```
 
 Currently, the suffix `/ai-bots-love.md` is hardcoded on purpose.
@@ -146,6 +148,36 @@ For best results, wrap your main content in a `<main>` element:
     <footer>...</footer>
 </body>
 ```
+
+### Excluding Content from Markdown
+
+Beyond the `<main>` selection and the configurable `removeElements` list, you
+can mark template regions explicitly via two bundled Fluid partials. They are
+auto-registered through the site set, so no `partialRootPaths` setup is
+required.
+
+Wrap a region you want **excluded** from the markdown output (teasers,
+related-article boxes, breadcrumbs, CTAs):
+
+```html
+<f:render partial="MarkdownExclude" contentAs="content">
+    <div class="teaser">Read also: …</div>
+</f:render>
+```
+
+Or **explicitly mark the main content region** (overrides `<main>` detection,
+useful when `<main>` is missing or contains too much):
+
+```html
+<f:render partial="MarkdownInclude" contentAs="content">
+    <article>… real content …</article>
+</f:render>
+```
+
+Both partials emit HTML comments (`<!-- markdown-start -->`,
+`<!-- markdown-exclude-start -->`, …) that survive caching and are stripped
+from regular page responses by a frontend middleware before they reach human
+visitors. Excludes can be **nested**.
 
 ## License
 

--- a/Resources/Private/Partials/MarkdownExclude.html
+++ b/Resources/Private/Partials/MarkdownExclude.html
@@ -1,0 +1,7 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:if condition="{content}">
+<!-- markdown-exclude-start -->
+{content -> f:format.raw()}
+<!-- markdown-exclude-end -->
+</f:if>
+</html>

--- a/Resources/Private/Partials/MarkdownInclude.html
+++ b/Resources/Private/Partials/MarkdownInclude.html
@@ -1,0 +1,7 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:if condition="{content}">
+<!-- markdown-start -->
+{content -> f:format.raw()}
+<!-- markdown-end -->
+</f:if>
+</html>

--- a/Tests/Unit/Middleware/MarkdownResponseMiddlewareMarkerTest.php
+++ b/Tests/Unit/Middleware/MarkdownResponseMiddlewareMarkerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Tests\Unit\Middleware;
+
+use B13\AiBotsLoveMarkdown\Middleware\MarkdownResponseMiddleware;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Tests the marker-related private methods of MarkdownResponseMiddleware
+ * (extractMainContent, removeExcludedSections, stripMarkers, extractBetweenMarkers)
+ * via reflection. The middleware is exercised end-to-end by functional tests.
+ */
+final class MarkdownResponseMiddlewareMarkerTest extends UnitTestCase
+{
+    private function invoke(string $method, string $input): string|null
+    {
+        $reflection = new ReflectionClass(MarkdownResponseMiddleware::class);
+        $middleware = $reflection->newInstanceWithoutConstructor();
+        return $reflection->getMethod($method)->invoke($middleware, $input);
+    }
+
+    #[Test]
+    public function extractMainContentPrefersMarkersOverMain(): void
+    {
+        $html = '<html><body><main><p>main</p></main>'
+            . '<!-- markdown-start --><p>marked</p><!-- markdown-end --></body></html>';
+
+        self::assertSame('<p>marked</p>', $this->invoke('extractMainContent', $html));
+    }
+
+    #[Test]
+    public function extractMainContentFallsBackToMainWhenNoMarkers(): void
+    {
+        $html = '<html><body><main><p>main</p></main></body></html>';
+
+        self::assertSame('<p>main</p>', $this->invoke('extractMainContent', $html));
+    }
+
+    #[Test]
+    public function extractMainContentFallsBackToBodyWhenNoMainOrMarkers(): void
+    {
+        $html = '<html><body><p>body</p></body></html>';
+
+        self::assertSame('<p>body</p>', $this->invoke('extractMainContent', $html));
+    }
+
+    #[Test]
+    public function removeExcludedSectionsDropsSimpleRegion(): void
+    {
+        $html = '<p>keep</p>'
+            . '<!-- markdown-exclude-start --><div>drop</div><!-- markdown-exclude-end -->'
+            . '<p>also keep</p>';
+
+        $out = $this->invoke('removeExcludedSections', $html);
+        self::assertStringNotContainsString('drop', (string)$out);
+        self::assertStringContainsString('keep', (string)$out);
+        self::assertStringContainsString('also keep', (string)$out);
+    }
+
+    #[Test]
+    public function removeExcludedSectionsHandlesNesting(): void
+    {
+        $html = '<p>before</p>'
+            . '<!-- markdown-exclude-start -->outer'
+            . '<!-- markdown-exclude-start -->inner<!-- markdown-exclude-end -->'
+            . 'outer-tail<!-- markdown-exclude-end -->'
+            . '<p>after</p>';
+
+        $out = $this->invoke('removeExcludedSections', $html);
+        self::assertStringNotContainsString('outer', (string)$out);
+        self::assertStringNotContainsString('inner', (string)$out);
+        self::assertStringContainsString('before', (string)$out);
+        self::assertStringContainsString('after', (string)$out);
+    }
+
+    #[Test]
+    public function removeExcludedSectionsLeavesUnpairedStartAlone(): void
+    {
+        $html = '<p>before</p><!-- markdown-exclude-start --><p>orphan</p>';
+
+        self::assertSame($html, $this->invoke('removeExcludedSections', $html));
+    }
+
+    #[Test]
+    public function stripMarkersRemovesAllFourMarkerVariants(): void
+    {
+        $html = '<!-- markdown-start --><!-- markdown-end -->'
+            . '<!-- markdown-exclude-start --><!-- markdown-exclude-end -->X';
+
+        self::assertSame('X', $this->invoke('stripMarkers', $html));
+    }
+}

--- a/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
+++ b/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Tests\Unit\Middleware;
+
+use B13\AiBotsLoveMarkdown\Middleware\StripMarkdownMarkersMiddleware;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class StripMarkdownMarkersMiddlewareTest extends UnitTestCase
+{
+    private function createResponseWithBody(string $body, string $contentType = 'text/html; charset=utf-8'): ResponseInterface
+    {
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        return (new Response())
+            ->withHeader('Content-Type', $contentType)
+            ->withBody($stream);
+    }
+
+    private function createHandler(ResponseInterface $response): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+        return $handler;
+    }
+
+    #[Test]
+    public function stripsAllMarkersFromHtmlResponse(): void
+    {
+        $html = '<html><body>'
+            . '<!-- markdown-start --><p>Content</p><!-- markdown-end -->'
+            . '<!-- markdown-exclude-start --><aside>Ad</aside><!-- markdown-exclude-end -->'
+            . '</body></html>';
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            new ServerRequest('https://example.com/', 'GET'),
+            $this->createHandler($this->createResponseWithBody($html))
+        );
+
+        $body = (string)$response->getBody();
+        self::assertStringNotContainsString('<!-- markdown-', $body);
+        self::assertStringContainsString('<p>Content</p>', $body);
+        self::assertStringContainsString('<aside>Ad</aside>', $body);
+    }
+
+    #[Test]
+    public function doesNotModifyNonHtmlResponse(): void
+    {
+        $json = '{"data": "<!-- markdown-start -->"}';
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            new ServerRequest('https://example.com/', 'GET'),
+            $this->createHandler($this->createResponseWithBody($json, 'application/json'))
+        );
+
+        self::assertStringContainsString('<!-- markdown-start -->', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function doesNotModifyMarkdownResponse(): void
+    {
+        $markdown = "# Title\n\n<!-- markdown-start --> stays in code block";
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            new ServerRequest('https://example.com/', 'GET'),
+            $this->createHandler($this->createResponseWithBody($markdown, 'text/markdown; charset=utf-8'))
+        );
+
+        self::assertStringContainsString('<!-- markdown-start -->', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function returnsOriginalResponseWhenNoMarkersPresent(): void
+    {
+        $html = '<html><body><p>No markers here</p></body></html>';
+
+        $original = $this->createResponseWithBody($html);
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            new ServerRequest('https://example.com/', 'GET'),
+            $this->createHandler($original)
+        );
+
+        self::assertSame($original, $response);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
 		"typo3/cms-core": "^13.4 || ^14.0",
 		"league/html-to-markdown": "^5.1"
 	},
+	"require-dev": {
+		"typo3/testing-framework": "^8.2 || ^9.1",
+		"phpunit/phpunit": "^10.5 || ^11.3"
+	},
 	"extra": {
 		"typo3/cms": {
 			"extension-key": "ai_bots_love_markdown"
@@ -16,6 +20,20 @@
 	"autoload": {
 		"psr-4": {
 			"B13\\AiBotsLoveMarkdown\\": "Classes/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"B13\\AiBotsLoveMarkdown\\Tests\\": "Tests/"
+		}
+	},
+	"scripts": {
+		"test:unit": "phpunit -c Build/phpunit/UnitTests.xml"
+	},
+	"config": {
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
 		"league/html-to-markdown": "^5.1"
 	},
 	"require-dev": {
-		"typo3/testing-framework": "^8.2 || ^9.1",
-		"phpunit/phpunit": "^10.5 || ^11.3"
+		"typo3/testing-framework": "^9.1",
+		"phpunit/phpunit": "^11.3"
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
## Summary

- Introduces `MarkdownInclude` / `MarkdownExclude` Fluid partials that emit HTML-comment markers driving content selection/exclusion in the markdown response — same proven pattern as `b13/vgwort-pro`.
- `MarkdownResponseMiddleware` resolves content via priority: marker region → `<main>` → `<body>`, then drops `markdown-exclude-*` regions (depth-aware, defensive against orphans).
- New `StripMarkdownMarkersMiddleware` (after `content-length-headers`) removes any marker from regular HTML responses so visitors never see them.
- `removeElements` is now a site setting; default no longer includes `<header>` so article-level `<header>` holding the page H1 reaches the markdown output (BEXT-587).
- Partial root paths auto-registered via the site set — integrators don't have to wire them manually.
- Initial PHPUnit scaffolding plus unit tests for marker priority, nested excludes, orphan markers and the strip middleware.

## Why

Until now the only content exclusion happened via hardcoded element stripping (`<nav> <footer> <aside> <header> …`) plus `<main>` selection. That couldn't address content **inside** `<main>` such as teaser boxes, related-article rails or breadcrumbs. The marker pattern from `vgwort-pro` solves exactly this and ports cleanly because it is pure HTML comments — cache-stable, language-agnostic, no DOM parser needed.

## How a template uses it

```html
<f:render partial="MarkdownExclude" contentAs="content">
    <div class="teaser">…</div>
</f:render>

<f:render partial="MarkdownInclude" contentAs="content">
    <article>… real content …</article>
</f:render>
```

Excludes can be nested. Markers are stripped from regular page responses by the new middleware.

## Test plan

- [x] `composer test:unit` — 11 tests / 18 assertions green
- [x] End-to-end in `b13-website-blog` (TYPO3 14.3, DDEV) — markdown response works, HTML response contains zero markers
- [x] Marker pipeline tested in real DDEV runtime: marker priority over `<main>`, nested excludes dropped, all markers stripped from final output, orphan markers leave content unchanged
- [ ] Reviewer: try a real template marker in production templates and verify the rendered markdown excludes the marked region

## Related

- Independent follow-ups already filed: BEXT-582 to BEXT-588 (header stripping inside `<main>` — addressed here as part of BEXT-587; double-decode, sys_category caching, discovery-tag coupling, srcset support, full test infrastructure).