### PR TITLE
[FEATURE] Build Html Converter Event

### DIFF
--- a/Classes/Event/BuildHtmlMarkdownConverterEvent.php
+++ b/Classes/Event/BuildHtmlMarkdownConverterEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Event;
+
+use League\HTMLToMarkdown\Converter\ConverterInterface;
+use League\HTMLToMarkdown\Converter\TableConverter;
+use League\HTMLToMarkdown\HtmlConverter;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Frontend\Page\PageInformation;
+
+/**
+ * Event to modify frontMatter or markdownContent.
+ */
+final class BuildHtmlMarkdownConverterEvent
+{
+    protected array $options = [
+        'strip_tags' => true,
+        'hard_break' => true,
+        'remove_nodes' => 'script style nav footer aside header form iframe noscript',
+    ];
+    protected $converters = [];
+
+    public function __construct(
+        public readonly ServerRequestInterface $request,
+    ) {
+        $this->converters[] = new TableConverter();
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function mergeOptions(array $options): void
+    {
+        $this->options = array_merge($this->options, $options);
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    public function setConverters(array $converters): void
+    {
+        foreach ($converters as $converter) {
+            $this->addConverter($converter);
+        }
+    }
+
+    public function addConverter(ConverterInterface $converter): void
+    {
+        $this->converters[] = $converter;
+    }
+
+    public function getConverters(): array
+    {
+        return $this->converters;
+    }
+
+    public function getHtmlConverter(): HtmlConverter
+    {
+        $htmlConverter = new HtmlConverter($this->options);
+        foreach ($this->converters as $converter) {
+            $htmlConverter->getEnvironment()->addConverter($converter);
+        }
+        return $htmlConverter;
+    }
+}

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace B13\AiBotsLoveMarkdown\Middleware;
 
 use B13\AiBotsLoveMarkdown\Event\AfterMarkdownConversionEvent;
+use B13\AiBotsLoveMarkdown\Event\BuildHtmlMarkdownConverterEvent;
 use B13\AiBotsLoveMarkdown\Service\HtmlToMarkdownService;
 use B13\AiBotsLoveMarkdown\Service\MetadataService;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -109,8 +110,12 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         // Get page title for H1 (from og:title, title tag, or page record)
         $pageTitle = $this->extractPageTitle($html, $pageRecord);
 
+        $buildHtmlConverterEvent = new BuildHtmlMarkdownConverterEvent($request);
+        $this->eventDispatcher->dispatch($buildHtmlConverterEvent);
+        $converter = $buildHtmlConverterEvent->getHtmlConverter();
+
         // Convert HTML to Markdown
-        $markdownContent = $pageTitle . $this->htmlToMarkdownService->convert($content, $baseUrl);
+        $markdownContent = $pageTitle . $this->htmlToMarkdownService->convert($content, $baseUrl, $converter);
 
         // Dispatch event to allow modification of the markdown output
         $event = $this->eventDispatcher->dispatch(

--- a/Classes/Service/HtmlToMarkdownService.php
+++ b/Classes/Service/HtmlToMarkdownService.php
@@ -17,52 +17,20 @@ use League\HTMLToMarkdown\HtmlConverter;
 
 class HtmlToMarkdownService
 {
-    private HtmlConverter $converter;
 
-    public function __construct()
+    public function convert(string $html, string $baseUrl, HtmlConverter $converter): string
     {
-        $this->converter = new HtmlConverter([
-            'strip_tags' => true,
-            'hard_break' => true,
-            'remove_nodes' => 'script style nav footer aside header form iframe',
-        ]);
-        $this->converter->getEnvironment()->addConverter(new TableConverter());
-    }
-
-    public function convert(string $html, string $baseUrl = ''): string
-    {
-        // Remove navigation, footer, aside elements
-        $html = $this->removeNonContentElements($html);
-
         // Make image URLs absolute
         if ($baseUrl !== '') {
             $html = $this->makeUrlsAbsolute($html, $baseUrl);
         }
 
-        $markdown = $this->converter->convert($html);
+        $markdown = $converter->convert($html);
 
         // Clean up excessive whitespace
         $markdown = $this->cleanupMarkdown($markdown);
 
         return $markdown;
-    }
-
-    private function removeNonContentElements(string $html): string
-    {
-        // Remove elements that typically don't contain main content
-        $patterns = [
-            '/<nav\b[^>]*>.*?<\/nav>/is',
-            '/<footer\b[^>]*>.*?<\/footer>/is',
-            '/<aside\b[^>]*>.*?<\/aside>/is',
-            '/<header\b[^>]*>.*?<\/header>/is',
-            '/<form\b[^>]*>.*?<\/form>/is',
-            '/<script\b[^>]*>.*?<\/script>/is',
-            '/<style\b[^>]*>.*?<\/style>/is',
-            '/<iframe\b[^>]*>.*?<\/iframe>/is',
-            '/<noscript\b[^>]*>.*?<\/noscript>/is',
-        ];
-
-        return preg_replace($patterns, '', $html) ?? $html;
     }
 
     private function makeUrlsAbsolute(string $html, string $baseUrl): string


### PR DESCRIPTION
* dispatch an Event to modify HtmlConverter behaviour
* use remove_nodes from HtmlConverter instead of removeNonContentElements in Service

e.g. do not remove form tags from markdown output

class BuildHtmlMarkdownConverterEventListener
{
    public function __invoke(BuildHtmlMarkdownConverterEvent $e)
    {
        $options = $e->getOptions();
        $removeNodes = GeneralUtility::trimExplode(' ', $options['remove_nodes'] ?? '');
        $removeNodes = array_diff($removeNodes, ['form']);
        $e->mergeOptions(['remove_nodes' => implode(' ', $removeNodes)]);
    }
}