### PR TITLE
[FEATURE] Add event to extend YAML front matter

### DIFF
--- a/Classes/Event/AfterFrontMatterForPageIsCreatedEvent.php
+++ b/Classes/Event/AfterFrontMatterForPageIsCreatedEvent.php
@@ -16,12 +16,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
 /**
- * Event to modify the YAML front matter data array before it is rendered.
+ * Fired after the YAML front-matter data array has been assembled from meta
+ * tags and the page record, but before it is rendered to a YAML string.
  *
  * Listeners can add, remove, or replace entries in the $frontMatter array.
  * The array preserves insertion order, which is reflected in the rendered YAML.
  */
-final class ModifyFrontMatterDataEvent
+final class AfterFrontMatterForPageIsCreatedEvent
 {
     public function __construct(
         public array $frontMatter,

--- a/Classes/Event/ModifyFrontMatterDataEvent.php
+++ b/Classes/Event/ModifyFrontMatterDataEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Event;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Frontend\Page\PageInformation;
+
+/**
+ * Event to modify the YAML front matter data array before it is rendered.
+ *
+ * Listeners can add, remove, or replace entries in the $frontMatter array.
+ * The array preserves insertion order, which is reflected in the rendered YAML.
+ */
+final class ModifyFrontMatterDataEvent
+{
+    public function __construct(
+        public array $frontMatter,
+        public readonly array $pageRecord,
+        public readonly string $html,
+        public readonly ?PageInformation $pageInformation,
+        public readonly ?ServerRequestInterface $request,
+    ) {}
+}

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -135,7 +135,7 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $content = $this->stripMarkers($content);
 
         // Generate front matter from meta tags (with page record as fallback).
-        // Pass PageInformation + request so listeners on ModifyFrontMatterDataEvent
+        // Pass PageInformation + request so listeners on AfterFrontMatterForPageIsCreatedEvent
         // have full request context.
         $frontMatter = $this->metadataService->generateFrontMatter(
             $html,

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -134,8 +134,16 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         // Defense-in-depth: strip residual markers before converter sees the HTML
         $content = $this->stripMarkers($content);
 
-        // Generate front matter from meta tags (with page record as fallback)
-        $frontMatter = $this->metadataService->generateFrontMatter($html, $pageRecord, $fallbackUrl);
+        // Generate front matter from meta tags (with page record as fallback).
+        // Pass PageInformation + request so listeners on ModifyFrontMatterDataEvent
+        // have full request context.
+        $frontMatter = $this->metadataService->generateFrontMatter(
+            $html,
+            $pageRecord,
+            $fallbackUrl,
+            $pageInformation instanceof PageInformation ? $pageInformation : null,
+            $request,
+        );
 
         // Get page title for H1 (from og:title, title tag, or page record)
         $pageTitle = $this->extractPageTitle($html, $pageRecord);

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -12,7 +12,7 @@ namespace B13\AiBotsLoveMarkdown\Service;
  * of the License, or any later version.
  */
 
-use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use B13\AiBotsLoveMarkdown\Event\AfterFrontMatterForPageIsCreatedEvent;
 use Doctrine\DBAL\ParameterType;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,7 +30,7 @@ final readonly class MetadataService
      * Generate YAML front matter from HTML meta tags and page record.
      *
      * Meta tags take priority, page record is used as fallback.
-     * Dispatches {@see ModifyFrontMatterDataEvent} so listeners can add or
+     * Dispatches {@see AfterFrontMatterForPageIsCreatedEvent} so listeners can add or
      * modify entries before the array is rendered to YAML.
      */
     public function generateFrontMatter(
@@ -43,7 +43,7 @@ final readonly class MetadataService
         $frontMatter = $this->buildFrontMatterData($html, $pageRecord, $fallbackUrl);
 
         $event = $this->eventDispatcher->dispatch(
-            new ModifyFrontMatterDataEvent(
+            new AfterFrontMatterForPageIsCreatedEvent(
                 frontMatter: $frontMatter,
                 pageRecord: $pageRecord,
                 html: $html,

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -12,20 +12,56 @@ namespace B13\AiBotsLoveMarkdown\Service;
  * of the License, or any later version.
  */
 
+use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
 use Doctrine\DBAL\ParameterType;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Frontend\Page\PageInformation;
 
 final readonly class MetadataService
 {
     public function __construct(
         protected ConnectionPool $connectionPool,
+        protected EventDispatcherInterface $eventDispatcher,
     ) {}
 
     /**
-     * Generate YAML front matter from HTML meta tags and page record
-     * Meta tags take priority, page record is used as fallback
+     * Generate YAML front matter from HTML meta tags and page record.
+     *
+     * Meta tags take priority, page record is used as fallback.
+     * Dispatches {@see ModifyFrontMatterDataEvent} so listeners can add or
+     * modify entries before the array is rendered to YAML.
      */
-    public function generateFrontMatter(string $html, array $pageRecord, string $fallbackUrl): string
+    public function generateFrontMatter(
+        string $html,
+        array $pageRecord,
+        string $fallbackUrl,
+        ?PageInformation $pageInformation = null,
+        ?ServerRequestInterface $request = null,
+    ): string {
+        $frontMatter = $this->buildFrontMatterData($html, $pageRecord, $fallbackUrl);
+
+        $event = $this->eventDispatcher->dispatch(
+            new ModifyFrontMatterDataEvent(
+                frontMatter: $frontMatter,
+                pageRecord: $pageRecord,
+                html: $html,
+                pageInformation: $pageInformation,
+                request: $request,
+            )
+        );
+
+        return $this->renderYaml($event->frontMatter);
+    }
+
+    /**
+     * Assemble the front-matter data array from HTML meta tags and the page record.
+     *
+     * Exposed as a separate step so integrators with their own rendering pipeline
+     * can grab the structured array directly.
+     */
+    public function buildFrontMatterData(string $html, array $pageRecord, string $fallbackUrl): array
     {
         // Extract metadata from HTML meta tags
         $metaTags = $this->extractMetaTags($html);
@@ -102,6 +138,14 @@ final readonly class MetadataService
             $frontMatter['locale'] = $metaTags['og:locale'];
         }
 
+        return $frontMatter;
+    }
+
+    /**
+     * Render a front-matter data array to a YAML front-matter block.
+     */
+    public function renderYaml(array $frontMatter): string
+    {
         return $this->formatYamlFrontMatter($frontMatter);
     }
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ visitors. Excludes can be **nested**.
 
 The default front matter is built from HTML meta tags and the page record. To
 add domain-specific keys (e.g. seminar data, product attributes, event dates),
-listen to the `ModifyFrontMatterDataEvent`. Listeners receive the assembled
+listen to the `AfterFrontMatterForPageIsCreatedEvent`. Listeners receive the assembled
 data array **before** it is rendered to YAML and may add, remove, or replace
 entries.
 
@@ -206,7 +206,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MySite\EventListener;
 
-use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use B13\AiBotsLoveMarkdown\Event\AfterFrontMatterForPageIsCreatedEvent;
 use MyVendor\MySite\Domain\Repository\SeminarRepository;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 
@@ -217,7 +217,7 @@ final readonly class AddSeminarFrontMatter
     ) {}
 
     #[AsEventListener]
-    public function __invoke(ModifyFrontMatterDataEvent $event): void
+    public function __invoke(AfterFrontMatterForPageIsCreatedEvent $event): void
     {
         $pageId = (int)($event->pageRecord['uid'] ?? 0);
         $seminar = $this->seminarRepository->findByDetailPageId($pageId);

--- a/README.md
+++ b/README.md
@@ -191,6 +191,60 @@ Both partials emit HTML comments (`<!-- markdown-start -->`,
 from regular page responses by a frontend middleware before they reach human
 visitors. Excludes can be **nested**.
 
+### Extending the YAML front matter
+
+The default front matter is built from HTML meta tags and the page record. To
+add domain-specific keys (e.g. seminar data, product attributes, event dates),
+listen to the `ModifyFrontMatterDataEvent`. Listeners receive the assembled
+data array **before** it is rendered to YAML and may add, remove, or replace
+entries.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MySite\EventListener;
+
+use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use MyVendor\MySite\Domain\Repository\SeminarRepository;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+final readonly class AddSeminarFrontMatter
+{
+    public function __construct(
+        private SeminarRepository $seminarRepository,
+    ) {}
+
+    #[AsEventListener]
+    public function __invoke(ModifyFrontMatterDataEvent $event): void
+    {
+        $pageId = (int)($event->pageRecord['uid'] ?? 0);
+        $seminar = $this->seminarRepository->findByDetailPageId($pageId);
+        if ($seminar === null) {
+            return;
+        }
+
+        $event->frontMatter['seminar_title'] = $seminar->getTitle();
+        $event->frontMatter['seminar_instructor'] = $seminar->getInstructor()?->getDisplayName();
+        $event->frontMatter['seminar_price_eur'] = number_format($seminar->getPriceCents() / 100, 2, '.', '');
+        $event->frontMatter['seminar_dates'] = array_map(
+            static fn (\DateTimeImmutable $d) => $d->format('Y-m-d'),
+            $seminar->getDates(),
+        );
+    }
+}
+```
+
+The event also exposes `$html`, `$pageInformation`, and `$request` (each
+read-only) so listeners can resolve site, language, or routing information
+when needed. Array order is preserved in the rendered YAML, so you can
+prepend custom keys by recreating the array if order matters.
+
+If you need to bypass the YAML rendering entirely, the underlying methods
+`MetadataService::buildFrontMatterData()` and `MetadataService::renderYaml()`
+are public and can be used directly.
+
 ## License
 
 The extension is licensed under GPL v2+, same as the TYPO3 Core.


### PR DESCRIPTION
## Summary

Adds `ModifyFrontMatterDataEvent` so site packages can inject domain-specific
keys (seminar attributes, product fields, event dates, …) into the YAML front
matter without patching the extension or post-processing the rendered YAML
string.

The existing `AfterMarkdownConversionEvent` only exposes the already-rendered
YAML string, so listeners would have to manipulate YAML as text. The new
event fires earlier and exposes the structured data array, mutable.

## Changes

- **New:** `Classes/Event/ModifyFrontMatterDataEvent.php` — carries
  `frontMatter` (mutable `array`), `pageRecord`, `html`, `?PageInformation`,
  `?ServerRequestInterface`.
- **Refactor:** `MetadataService` is split into three public methods:
  - `buildFrontMatterData(): array`
  - `renderYaml(array): string`
  - `generateFrontMatter(...): string` — orchestrates + dispatches event

  Constructor gains an `EventDispatcherInterface` dependency (auto-wired).
  `generateFrontMatter()` gains two **optional** parameters
  (`?PageInformation`, `?ServerRequestInterface`) — no BC break.
- **Middleware:** `MarkdownResponseMiddleware` forwards `$pageInformation` and
  `$request` to `generateFrontMatter()`.
- **README:** new section *Extending the YAML front matter* with a worked
  example.

## Why event over alternatives

- **Service-registry with `FrontMatterProviderInterface`:** more boilerplate,
  no benefit over an event for this use case.
- **YAML site-set configuration:** can only express static
  `pages.column → yaml.key` mappings; cannot do joins to domain tables,
  computed values, or conditional inclusion.
- **PSR-14 event:** TYPO3 v14 standard pattern, low friction
  (`#[AsEventListener]` + autoconfigure), full flexibility.

## Test plan

- [x] PHP syntax-lint passes for all changed files
- [x] Wire a throwaway listener in a downstream site, request a page with
      `Accept: text/markdown`, verify injected key appears in front matter
- [x] Verify existing `AfterMarkdownConversionEvent` listeners still fire
- [ ] Functional test for `MetadataService` with a mock listener (follow-up —
      repo currently has no `Tests/` directory)

## Notes

- No `Services.yaml` change needed — autowire picks up the new
  `EventDispatcherInterface` dependency.
- Suggest tagging as `0.3.0` once merged — additive feature, no breaking
  changes.