### PR TITLE
[FEATURE] Doktype + per-page exclusion from Markdown alternate

### DIFF
--- a/Classes/Backend/TcaCondition/HideOnExcludedDoktype.php
+++ b/Classes/Backend/TcaCondition/HideOnExcludedDoktype.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  * TCA displayCond user function: hide a field on pages whose doktype is in
  * the site's `ai_bots_love_markdown.excludedDoktypes` list.
  *
- * Used by the `pages.no_markdown_version` toggle so editors don't see a
+ * Used by the `pages.markdown_version` toggle so editors don't see a
  * "Disable Markdown version" switch on doktypes that never produce markdown
  * anyway (cart, wishlist, mountpoint, sysfolder, recycler, ...).
  */

--- a/Classes/Backend/TcaCondition/HideOnExcludedDoktype.php
+++ b/Classes/Backend/TcaCondition/HideOnExcludedDoktype.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Backend\TcaCondition;
+
+use B13\AiBotsLoveMarkdown\Service\MarkdownExclusionService;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Site\SiteFinder;
+
+/**
+ * TCA displayCond user function: hide a field on pages whose doktype is in
+ * the site's `ai_bots_love_markdown.excludedDoktypes` list.
+ *
+ * Used by the `pages.no_markdown_version` toggle so editors don't see a
+ * "Disable Markdown version" switch on doktypes that never produce markdown
+ * anyway (cart, wishlist, mountpoint, sysfolder, recycler, ...).
+ */
+final readonly class HideOnExcludedDoktype
+{
+    public function __construct(
+        private MarkdownExclusionService $exclusionService,
+        private SiteFinder $siteFinder,
+    ) {}
+
+    /**
+     * @param array{record: array<string, mixed>} $parameters
+     */
+    public function match(array $parameters): bool
+    {
+        $record = $parameters['record'] ?? [];
+        $doktype = (int)($record['doktype'] ?? 0);
+        if ($doktype === 0) {
+            return true;
+        }
+
+        // For an existing page, $record['uid'] is the page itself; for a new
+        // page-to-be the uid is still missing, so fall back to the parent pid
+        // to locate the surrounding site.
+        $pageIdForSiteLookup = (int)($record['uid'] ?? 0);
+        if ($pageIdForSiteLookup === 0) {
+            $pageIdForSiteLookup = (int)($record['pid'] ?? 0);
+        }
+        if ($pageIdForSiteLookup === 0) {
+            return true;
+        }
+
+        try {
+            $site = $this->siteFinder->getSiteByPageId($pageIdForSiteLookup);
+        } catch (SiteNotFoundException) {
+            return true;
+        }
+
+        // Show the field only when the doktype is NOT in the exclusion list.
+        // We synthesize a minimal record so the service can run its plain
+        // doktype check without re-reading the page.
+        return !$this->exclusionService->isExcluded(
+            ['doktype' => $doktype],
+            $site,
+        );
+    }
+}

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -15,6 +15,7 @@ namespace B13\AiBotsLoveMarkdown\Middleware;
 use B13\AiBotsLoveMarkdown\Event\AfterMarkdownConversionEvent;
 use B13\AiBotsLoveMarkdown\Event\BuildHtmlMarkdownConverterEvent;
 use B13\AiBotsLoveMarkdown\Service\HtmlToMarkdownService;
+use B13\AiBotsLoveMarkdown\Service\MarkdownExclusionService;
 use B13\AiBotsLoveMarkdown\Service\MetadataService;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -47,6 +48,7 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         private HtmlToMarkdownService $htmlToMarkdownService,
         private MetadataService $metadataService,
         private EventDispatcherInterface $eventDispatcher,
+        private MarkdownExclusionService $exclusionService,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -63,6 +65,18 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $contentType = $response->getHeaderLine('Content-Type');
         if (!str_contains($contentType, 'text/html')) {
             return $response;
+        }
+
+        // Per-page / per-doktype exclusion: skip conversion and also strip
+        // the discovery link from the HTML so bots don't follow a dead alternate.
+        $pageRecord = [];
+        $pageInformation = $request->getAttribute('frontend.page.information');
+        if ($pageInformation instanceof PageInformation) {
+            $pageRecord = $pageInformation->getPageRecord();
+        }
+        $site = $request->getAttribute('site');
+        if ($this->exclusionService->isExcluded($pageRecord, $site instanceof Site ? $site : null)) {
+            return $this->stripDiscoveryLink($response);
         }
 
         // Get the HTML content
@@ -268,5 +282,24 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
             '',
             $html
         );
+    }
+
+    /**
+     * Remove the <link rel="alternate" type="text/markdown"> tag from the HTML
+     * response so user agents don't follow a dead markdown URL for excluded pages.
+     */
+    private function stripDiscoveryLink(ResponseInterface $response): ResponseInterface
+    {
+        $html = (string)$response->getBody();
+        $stripped = preg_replace(self::MARKDOWN_LINK_PATTERN, '', $html);
+        if ($stripped === null || $stripped === $html) {
+            return $response;
+        }
+
+        $body = new Stream('php://temp', 'rw');
+        $body->write($stripped);
+        $body->rewind();
+
+        return $response->withBody($body)->withoutHeader('Content-Length');
     }
 }

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -53,22 +53,19 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // Check if the early middleware marked this request for markdown conversion
-        if (!$request->getAttribute(MarkdownRequestMiddleware::MARKER_ATTRIBUTE)) {
-            return $handler->handle($request);
-        }
+        $isMarkdownRequest = (bool)$request->getAttribute(MarkdownRequestMiddleware::MARKER_ATTRIBUTE);
 
         // Let the normal page render
         $response = $handler->handle($request);
 
-        // Only process HTML responses
-        $contentType = $response->getHeaderLine('Content-Type');
-        if (!str_contains($contentType, 'text/html')) {
+        // We only ever touch HTML responses.
+        if (!str_contains($response->getHeaderLine('Content-Type'), 'text/html')) {
             return $response;
         }
 
-        // Per-page / per-doktype exclusion: skip conversion and also strip
-        // the discovery link from the HTML so bots don't follow a dead alternate.
+        // Per-page / per-doktype exclusion check runs for EVERY HTML response — not
+        // just markdown requests — so that bots crawling the regular HTML don't see
+        // a discovery link for a page that will never serve markdown.
         $pageRecord = [];
         $pageInformation = $request->getAttribute('frontend.page.information');
         if ($pageInformation instanceof PageInformation) {
@@ -76,7 +73,15 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         }
         $site = $request->getAttribute('site');
         if ($this->exclusionService->isExcluded($pageRecord, $site instanceof Site ? $site : null)) {
+            // For markdown requesters this is a graceful content-negotiation downgrade
+            // to HTML; for regular visitors the discovery link is removed so the dead
+            // alternate URL is never advertised.
             return $this->stripDiscoveryLink($response);
+        }
+
+        // Non-excluded pages: pass through unchanged unless a markdown alternate was requested.
+        if (!$isMarkdownRequest) {
+            return $response;
         }
 
         // Get the HTML content

--- a/Classes/Service/MarkdownExclusionService.php
+++ b/Classes/Service/MarkdownExclusionService.php
@@ -19,7 +19,9 @@ use TYPO3\CMS\Core\Site\Entity\Site;
  *
  * Two mechanisms, both checked:
  *  - Site setting `ai_bots_love_markdown.excludedDoktypes` (comma-separated doktype IDs)
- *  - TCA field `pages.no_markdown_version` (per-page editorial opt-out)
+ *  - TCA field `pages.markdown_version` (per-page editorial opt-out — affirmative
+ *    field with default 1; the BE renders the toggle inverted as "Disable Markdown
+ *    version")
  */
 final readonly class MarkdownExclusionService
 {
@@ -27,7 +29,12 @@ final readonly class MarkdownExclusionService
 
     public function isExcluded(array $pageRecord, ?Site $site): bool
     {
-        if ((int)($pageRecord['no_markdown_version'] ?? 0) === 1) {
+        // Per-page opt-out: when `markdown_version` is explicitly 0 the editor
+        // turned the toggle on ("Disable Markdown version" because the BE renders
+        // it inverted). Default-on means missing-or-1 keeps markdown enabled.
+        if (array_key_exists('markdown_version', $pageRecord)
+            && (int)$pageRecord['markdown_version'] === 0
+        ) {
             return true;
         }
 

--- a/Classes/Service/MarkdownExclusionService.php
+++ b/Classes/Service/MarkdownExclusionService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Service;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+
+/**
+ * Decides whether a page is excluded from producing a Markdown alternate response.
+ *
+ * Two mechanisms, both checked:
+ *  - Site setting `ai_bots_love_markdown.excludedDoktypes` (comma-separated doktype IDs)
+ *  - TCA field `pages.no_markdown_version` (per-page editorial opt-out)
+ */
+final readonly class MarkdownExclusionService
+{
+    private const SETTING_KEY = 'ai_bots_love_markdown.excludedDoktypes';
+
+    public function isExcluded(array $pageRecord, ?Site $site): bool
+    {
+        if ((int)($pageRecord['no_markdown_version'] ?? 0) === 1) {
+            return true;
+        }
+
+        $doktype = (int)($pageRecord['doktype'] ?? 0);
+        if ($doktype === 0) {
+            return false;
+        }
+
+        return in_array($doktype, $this->resolveExcludedDoktypes($site), true);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function resolveExcludedDoktypes(?Site $site): array
+    {
+        if ($site === null) {
+            return [];
+        }
+
+        $raw = trim((string)$site->getSettings()->get(self::SETTING_KEY, ''));
+        if ($raw === '') {
+            return [];
+        }
+
+        $ids = [];
+        foreach (explode(',', $raw) as $part) {
+            $trimmed = trim($part);
+            if ($trimmed !== '' && ctype_digit($trimmed)) {
+                $ids[] = (int)$trimmed;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,3 +6,8 @@ services:
 
   B13\AiBotsLoveMarkdown\:
     resource: '../Classes/*'
+
+  # TCA displayCond USER-funcs are resolved via GeneralUtility::makeInstance,
+  # which requires the service to be public in the container.
+  B13\AiBotsLoveMarkdown\Backend\TcaCondition\HideOnExcludedDoktype:
+    public: true

--- a/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
+++ b/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
@@ -19,3 +19,7 @@ settings:
     type: string
     default: 'script style nav footer aside form iframe noscript'
     label: 'Space-separated HTML tags to strip from markdown output'
+  ai_bots_love_markdown.excludedDoktypes:
+    type: string
+    default: '3,4,6,7,199,254,255'
+    label: 'Comma-separated page doktypes that never produce a Markdown alternate response (default: standard TYPO3 system doktypes)'

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+defined('TYPO3') or die();
+
+call_user_func(static function (): void {
+    $additionalColumns = [
+        'no_markdown_version' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:ai_bots_love_markdown/Resources/Private/Language/locallang_db.xlf:pages.no_markdown_version',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'default' => 0,
+            ],
+        ],
+    ];
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+        'pages',
+        'no_markdown_version',
+        '',
+        'after:no_search',
+    );
+});

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -14,9 +14,9 @@ defined('TYPO3') or die();
 
 call_user_func(static function (): void {
     $additionalColumns = [
-        'no_markdown_version' => [
+        'markdown_version' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:ai_bots_love_markdown/Resources/Private/Language/locallang_db.xlf:pages.no_markdown_version',
+            'label' => 'LLL:EXT:ai_bots_love_markdown/Resources/Private/Language/locallang_db.xlf:pages.markdown_version',
             // Hide on doktypes that are already in the site's `excludedDoktypes`
             // list — the toggle has no effect there, showing it would only confuse
             // editors. Site-aware lookup so projects can override the list.
@@ -24,7 +24,17 @@ call_user_func(static function (): void {
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
-                'default' => 0,
+                // Field is named in the affirmative ("markdown_version") with
+                // default-on, and the BE renders the toggle inverted so the
+                // editor sees / sets "Disable Markdown version". Keeps the
+                // PHP guard `!$row['markdown_version']` readable.
+                'default' => 1,
+                'items' => [
+                    [
+                        'label' => '',
+                        'invertStateDisplay' => true,
+                    ],
+                ],
             ],
         ],
     ];
@@ -32,7 +42,7 @@ call_user_func(static function (): void {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
-        'no_markdown_version',
+        'markdown_version',
         '',
         'after:no_search',
     );

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -17,6 +17,10 @@ call_user_func(static function (): void {
         'no_markdown_version' => [
             'exclude' => true,
             'label' => 'LLL:EXT:ai_bots_love_markdown/Resources/Private/Language/locallang_db.xlf:pages.no_markdown_version',
+            // Hide on doktypes that are already in the site's `excludedDoktypes`
+            // list — the toggle has no effect there, showing it would only confuse
+            // editors. Site-aware lookup so projects can override the list.
+            'displayCond' => 'USER:B13\\AiBotsLoveMarkdown\\Backend\\TcaCondition\\HideOnExcludedDoktype->match',
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ ai_bots_love_markdown.excludedDoktypes: '3,4,6,7,199,254,255,37,38,41'
 ### Per-page opt-out
 
 Editors can disable the Markdown alternate for individual pages via the page property
-**Disable Markdown version** (TCA field `pages.no_markdown_version`). When set, the
+**Disable Markdown version** (TCA field `pages.markdown_version`, default on, rendered
+inverted in the BE so the toggle reads as "disable"). When the toggle is turned on, the
 `<link rel="alternate">` discovery tag is stripped from the HTML response and any direct
 request to `.md` / `Accept: text/markdown` returns the regular HTML.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The extension provides two settings that can be configured per site (both enable
 | `ai_bots_love_markdown.pageTypeSuffix`           | `ai-bots-love.md`                                    | PageType Suffix for Markdown link                                                                                                                          |
 | `ai_bots_love_markdown.pageTypeTypeNum`          | `2026`                                               | PageType TypeNum for Markdown link                                                                                                                         |
 | `ai_bots_love_markdown.removeElements`           | `script style nav footer aside form iframe noscript` | Space-separated HTML tags stripped from the markdown output. `<header>` is intentionally not included — article-level `<header>` regions often hold the H1 |
+| `ai_bots_love_markdown.excludedDoktypes`         | `3,4,6,7,199,254,255`                                | Comma-separated page doktypes that never produce a Markdown alternate response. Default covers TYPO3 system doktypes (external link, shortcut, mountpoint, sysfolder, recycler, etc.) |
 
 To override these settings, add them to your site's `settings.yaml`:
 
@@ -48,7 +49,15 @@ ai_bots_love_markdown.enableDiscoveryTag: false
 ai_bots_love_markdown.pageTypeTypeNum: 1778074315
 ai_bots_love_markdown.pageTypeSuffix: 'foo.md'
 ai_bots_love_markdown.removeElements: 'script style nav footer aside form iframe noscript header'
+ai_bots_love_markdown.excludedDoktypes: '3,4,6,7,199,254,255,37,38,41'
 ```
+
+### Per-page opt-out
+
+Editors can disable the Markdown alternate for individual pages via the page property
+**Disable Markdown version** (TCA field `pages.no_markdown_version`). When set, the
+`<link rel="alternate">` discovery tag is stripped from the HTML response and any direct
+request to `.md` / `Accept: text/markdown` returns the regular HTML.
 
 
 ## Usage

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,9 +3,9 @@
 	<file source-language="en" datatype="plaintext" original="messages" date="2026-05-15T00:00:00Z" product-name="ai_bots_love_markdown">
 		<header/>
 		<body>
-			<trans-unit id="pages.no_markdown_version">
+			<trans-unit id="pages.markdown_version">
 				<source>Disable Markdown version</source>
-				<note>When enabled, this page will never serve a Markdown alternate response and the discovery link tag is not advertised.</note>
+				<note>Backed by the affirmative `pages.markdown_version` column (default 1, rendered inverted in the BE). Turn the toggle on to suppress the Markdown alternate response and discovery link for this page.</note>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
+	<file source-language="en" datatype="plaintext" original="messages" date="2026-05-15T00:00:00Z" product-name="ai_bots_love_markdown">
+		<header/>
+		<body>
+			<trans-unit id="pages.no_markdown_version">
+				<source>Disable Markdown version</source>
+				<note>When enabled, this page will never serve a Markdown alternate response and the discovery link tag is not advertised.</note>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Tests/Unit/Backend/TcaCondition/HideOnExcludedDoktypeTest.php
+++ b/Tests/Unit/Backend/TcaCondition/HideOnExcludedDoktypeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Tests\Unit\Backend\TcaCondition;
+
+use B13\AiBotsLoveMarkdown\Backend\TcaCondition\HideOnExcludedDoktype;
+use B13\AiBotsLoveMarkdown\Service\MarkdownExclusionService;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteSettings;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class HideOnExcludedDoktypeTest extends UnitTestCase
+{
+    private function siteWithExcludedDoktypes(string $value): Site
+    {
+        $settings = SiteSettings::createFromSettingsTree([
+            'ai_bots_love_markdown' => ['excludedDoktypes' => $value],
+        ]);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($settings);
+
+        return $site;
+    }
+
+    private function siteFinderResolving(int $pageId, Site $site): SiteFinder
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->with($pageId)->willReturn($site);
+
+        return $siteFinder;
+    }
+
+    #[Test]
+    public function showsFieldForContentDoktype(): void
+    {
+        $condition = new HideOnExcludedDoktype(
+            new MarkdownExclusionService(),
+            $this->siteFinderResolving(123, $this->siteWithExcludedDoktypes('3,4,254')),
+        );
+
+        self::assertTrue($condition->match([
+            'record' => ['uid' => 123, 'pid' => 1, 'doktype' => 1],
+        ]));
+    }
+
+    #[Test]
+    public function hidesFieldForDoktypeInExcludedList(): void
+    {
+        $condition = new HideOnExcludedDoktype(
+            new MarkdownExclusionService(),
+            $this->siteFinderResolving(123, $this->siteWithExcludedDoktypes('3,4,254')),
+        );
+
+        self::assertFalse($condition->match([
+            'record' => ['uid' => 123, 'pid' => 1, 'doktype' => 254],
+        ]));
+    }
+
+    #[Test]
+    public function fallsBackToPidForNewRecords(): void
+    {
+        $condition = new HideOnExcludedDoktype(
+            new MarkdownExclusionService(),
+            $this->siteFinderResolving(1, $this->siteWithExcludedDoktypes('254')),
+        );
+
+        // New record: no uid yet, pid points to parent
+        self::assertTrue($condition->match([
+            'record' => ['pid' => 1, 'doktype' => 1],
+        ]));
+    }
+
+    #[Test]
+    public function showsFieldWhenSiteCannotBeResolved(): void
+    {
+        $siteFinder = $this->createMock(SiteFinder::class);
+        $siteFinder->method('getSiteByPageId')->willThrowException(
+            new SiteNotFoundException('no site', 0),
+        );
+
+        $condition = new HideOnExcludedDoktype(new MarkdownExclusionService(), $siteFinder);
+
+        // When we can't resolve a site, fall open — better to show the field than hide it.
+        self::assertTrue($condition->match([
+            'record' => ['uid' => 999, 'pid' => 1, 'doktype' => 1],
+        ]));
+    }
+
+    #[Test]
+    public function showsFieldWhenRecordHasNoPidOrUid(): void
+    {
+        $condition = new HideOnExcludedDoktype(
+            new MarkdownExclusionService(),
+            $this->createMock(SiteFinder::class),
+        );
+
+        self::assertTrue($condition->match([
+            'record' => ['doktype' => 1],
+        ]));
+    }
+
+    #[Test]
+    public function showsFieldWhenDoktypeIsMissing(): void
+    {
+        $condition = new HideOnExcludedDoktype(
+            new MarkdownExclusionService(),
+            $this->createMock(SiteFinder::class),
+        );
+
+        self::assertTrue($condition->match([
+            'record' => ['uid' => 123, 'pid' => 1],
+        ]));
+    }
+}

--- a/Tests/Unit/Service/MarkdownExclusionServiceTest.php
+++ b/Tests/Unit/Service/MarkdownExclusionServiceTest.php
@@ -37,7 +37,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 1, 'no_markdown_version' => 0],
+            ['doktype' => 1, 'markdown_version' => 1],
             $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
         );
 
@@ -49,7 +49,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 254, 'no_markdown_version' => 0],
+            ['doktype' => 254, 'markdown_version' => 1],
             $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
         );
 
@@ -61,7 +61,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 1, 'no_markdown_version' => 1],
+            ['doktype' => 1, 'markdown_version' => 0],
             $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
         );
 
@@ -73,7 +73,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 1, 'no_markdown_version' => '1'], // string '1' from DB
+            ['doktype' => 1, 'markdown_version' => '0'], // string '0' from DB
             $this->siteWithExcludedDoktypes(''),
         );
 
@@ -85,7 +85,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 254, 'no_markdown_version' => 0],
+            ['doktype' => 254, 'markdown_version' => 1],
             $this->siteWithExcludedDoktypes(''),
         );
 
@@ -98,7 +98,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
         $service = new MarkdownExclusionService();
         // 'abc' and ' ' should be ignored, '254' should still match
         $excluded = $service->isExcluded(
-            ['doktype' => 254, 'no_markdown_version' => 0],
+            ['doktype' => 254, 'markdown_version' => 1],
             $this->siteWithExcludedDoktypes('abc, ,254, '),
         );
 
@@ -110,7 +110,7 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
     {
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
-            ['doktype' => 254, 'no_markdown_version' => 0],
+            ['doktype' => 254, 'markdown_version' => 1],
             null,
         );
 
@@ -123,6 +123,21 @@ final class MarkdownExclusionServiceTest extends UnitTestCase
         $service = new MarkdownExclusionService();
         $excluded = $service->isExcluded(
             [],
+            $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
+        );
+
+        self::assertFalse($excluded);
+    }
+
+    #[Test]
+    public function defaultsToIncludedWhenMarkdownVersionKeyIsMissing(): void
+    {
+        // pageRecord without the markdown_version field (e.g. legacy row from
+        // before the column was added) should behave as if the column carried
+        // its default value of 1 — i.e. NOT excluded.
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 1],
             $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
         );
 

--- a/Tests/Unit/Service/MarkdownExclusionServiceTest.php
+++ b/Tests/Unit/Service/MarkdownExclusionServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Tests\Unit\Service;
+
+use B13\AiBotsLoveMarkdown\Service\MarkdownExclusionService;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteSettings;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class MarkdownExclusionServiceTest extends UnitTestCase
+{
+    private function siteWithExcludedDoktypes(string $value): Site
+    {
+        $settings = SiteSettings::createFromSettingsTree([
+            'ai_bots_love_markdown' => ['excludedDoktypes' => $value],
+        ]);
+
+        $site = $this->createMock(Site::class);
+        $site->method('getSettings')->willReturn($settings);
+
+        return $site;
+    }
+
+    #[Test]
+    public function includesPageWithDefaultContentDoktypeAndNoOverride(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 1, 'no_markdown_version' => 0],
+            $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
+        );
+
+        self::assertFalse($excluded);
+    }
+
+    #[Test]
+    public function excludesPageWhenDoktypeInExcludedList(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 254, 'no_markdown_version' => 0],
+            $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
+        );
+
+        self::assertTrue($excluded);
+    }
+
+    #[Test]
+    public function excludesPageWhenPerPageFlagSet(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 1, 'no_markdown_version' => 1],
+            $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
+        );
+
+        self::assertTrue($excluded);
+    }
+
+    #[Test]
+    public function perPageFlagOverridesEvenWhenDoktypeNotExcluded(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 1, 'no_markdown_version' => '1'], // string '1' from DB
+            $this->siteWithExcludedDoktypes(''),
+        );
+
+        self::assertTrue($excluded);
+    }
+
+    #[Test]
+    public function ignoresEmptySetting(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 254, 'no_markdown_version' => 0],
+            $this->siteWithExcludedDoktypes(''),
+        );
+
+        self::assertFalse($excluded);
+    }
+
+    #[Test]
+    public function ignoresMalformedSettingEntries(): void
+    {
+        $service = new MarkdownExclusionService();
+        // 'abc' and ' ' should be ignored, '254' should still match
+        $excluded = $service->isExcluded(
+            ['doktype' => 254, 'no_markdown_version' => 0],
+            $this->siteWithExcludedDoktypes('abc, ,254, '),
+        );
+
+        self::assertTrue($excluded);
+    }
+
+    #[Test]
+    public function returnsFalseWhenSiteIsNullAndNoPerPageFlag(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            ['doktype' => 254, 'no_markdown_version' => 0],
+            null,
+        );
+
+        self::assertFalse($excluded);
+    }
+
+    #[Test]
+    public function returnsFalseForMissingDoktype(): void
+    {
+        $service = new MarkdownExclusionService();
+        $excluded = $service->isExcluded(
+            [],
+            $this->siteWithExcludedDoktypes('3,4,6,7,199,254,255'),
+        );
+
+        self::assertFalse($excluded);
+    }
+}


### PR DESCRIPTION
Adds two layered opt-out mechanisms so functional pages (cart, wishlist, checkout, error, mountpoints, sysfolders, recyclers, ...) never advertise or serve a Markdown alternate:

- Site setting `ai_bots_love_markdown.excludedDoktypes` (comma-separated doktype IDs, default `3,4,6,7,199,254,255` — TYPO3 system doktypes).
- TCA field `pages.no_markdown_version` (toggle), for per-page editorial opt-out without code changes.

`MarkdownExclusionService` encapsulates the decision; `MarkdownResponseMiddleware` checks before conversion and additionally strips the `<link rel="alternate">` discovery tag from the HTML response so bots don't follow a dead alternate URL. The existing opt-in check (discovery link present) then naturally short-circuits direct `.md` / `Accept: text/markdown` requests to the regular HTML.

8 new unit tests cover doktype match, per-page flag precedence, malformed settings, null site, missing doktype — all 19 tests green.