### PR TITLE
[FEATURE] YAML renderer: scalar tolerance, nested lists, consistent entity decoding

### DIFF
--- a/Classes/Event/AfterFrontMatterForPageIsCreatedEvent.php
+++ b/Classes/Event/AfterFrontMatterForPageIsCreatedEvent.php
@@ -16,12 +16,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
 /**
- * Event to modify the YAML front matter data array before it is rendered.
+ * Fired after the YAML front-matter data array has been assembled from meta
+ * tags and the page record, but before it is rendered to a YAML string.
  *
  * Listeners can add, remove, or replace entries in the $frontMatter array.
  * The array preserves insertion order, which is reflected in the rendered YAML.
  */
-final class ModifyFrontMatterDataEvent
+final class AfterFrontMatterForPageIsCreatedEvent
 {
     public function __construct(
         public array $frontMatter,

--- a/Classes/Event/ModifyFrontMatterDataEvent.php
+++ b/Classes/Event/ModifyFrontMatterDataEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Event;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Frontend\Page\PageInformation;
+
+/**
+ * Event to modify the YAML front matter data array before it is rendered.
+ *
+ * Listeners can add, remove, or replace entries in the $frontMatter array.
+ * The array preserves insertion order, which is reflected in the rendered YAML.
+ */
+final class ModifyFrontMatterDataEvent
+{
+    public function __construct(
+        public array $frontMatter,
+        public readonly array $pageRecord,
+        public readonly string $html,
+        public readonly ?PageInformation $pageInformation,
+        public readonly ?ServerRequestInterface $request,
+    ) {}
+}

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -135,7 +135,7 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $content = $this->stripMarkers($content);
 
         // Generate front matter from meta tags (with page record as fallback).
-        // Pass PageInformation + request so listeners on ModifyFrontMatterDataEvent
+        // Pass PageInformation + request so listeners on AfterFrontMatterForPageIsCreatedEvent
         // have full request context.
         $frontMatter = $this->metadataService->generateFrontMatter(
             $html,

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -134,8 +134,16 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         // Defense-in-depth: strip residual markers before converter sees the HTML
         $content = $this->stripMarkers($content);
 
-        // Generate front matter from meta tags (with page record as fallback)
-        $frontMatter = $this->metadataService->generateFrontMatter($html, $pageRecord, $fallbackUrl);
+        // Generate front matter from meta tags (with page record as fallback).
+        // Pass PageInformation + request so listeners on ModifyFrontMatterDataEvent
+        // have full request context.
+        $frontMatter = $this->metadataService->generateFrontMatter(
+            $html,
+            $pageRecord,
+            $fallbackUrl,
+            $pageInformation instanceof PageInformation ? $pageInformation : null,
+            $request,
+        );
 
         // Get page title for H1 (from og:title, title tag, or page record)
         $pageTitle = $this->extractPageTitle($html, $pageRecord);

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -68,11 +68,13 @@ final readonly class MetadataService
 
         $frontMatter = [];
 
-        // Title: og:title > meta title > page record
+        // Title: og:title > meta title > page record.
+        // pageRecord values come straight from TYPO3 and may carry HTML entities
+        // (e.g. "Automotive &amp; Mobility") — decode them so the YAML output
+        // matches what a human reader sees in the rendered page title.
         $frontMatter['title'] = $metaTags['og:title']
             ?? $metaTags['title']
-            ?? $pageRecord['title']
-            ?? '';
+            ?? $this->decodeEntities((string)($pageRecord['title'] ?? ''));
 
         // URL: canonical > fallback URL
         $frontMatter['url'] = $metaTags['canonical'] ?? $fallbackUrl;
@@ -80,8 +82,7 @@ final readonly class MetadataService
         // Description: og:description > meta description > page record
         $description = $metaTags['og:description']
             ?? $metaTags['description']
-            ?? $pageRecord['description']
-            ?? '';
+            ?? $this->decodeEntities((string)($pageRecord['description'] ?? ''));
         if ($description !== '') {
             $frontMatter['description'] = $description;
         }
@@ -92,20 +93,21 @@ final readonly class MetadataService
         }
 
         // Author: meta author > page record
-        $author = $metaTags['author'] ?? $pageRecord['author'] ?? '';
+        $author = $metaTags['author'] ?? $this->decodeEntities((string)($pageRecord['author'] ?? ''));
         if ($author !== '') {
             $frontMatter['author'] = $author;
         }
 
-        // Dates from page record (no standard meta tags for these)
+        // Dates from page record (no standard meta tags for these).
+        // SYS_LASTCHANGED is intentionally not surfaced as a separate
+        // "lastUpdated" key — it's almost always identical to tstamp and just
+        // adds noise. Listeners can add their own date keys via
+        // ModifyFrontMatterDataEvent when they need a domain-specific date.
         if (!empty($pageRecord['crdate'])) {
             $frontMatter['date'] = date('Y-m-d', (int)$pageRecord['crdate']);
         }
         if (!empty($pageRecord['tstamp'])) {
             $frontMatter['modified'] = date('Y-m-d', (int)$pageRecord['tstamp']);
-        }
-        if (!empty($pageRecord['SYS_LASTCHANGED'])) {
-            $frontMatter['lastUpdated'] = date('Y-m-d', (int)$pageRecord['SYS_LASTCHANGED']);
         }
 
         // Keywords from meta tags
@@ -152,13 +154,30 @@ final readonly class MetadataService
     /**
      * Extract meta tags from HTML
      */
+    /**
+     * Decode named / numeric HTML entities so values carried over from a page
+     * record (or any other not-yet-decoded source) render cleanly in YAML.
+     *
+     * We run the decode pass twice on purpose: some TYPO3 installations
+     * double-encode `og:title` content attributes (the raw page title is
+     * already entity-escaped and then the meta-tag renderer escapes it again),
+     * which leaves us with `&amp;amp;` in the source HTML. A single decode
+     * pass on a single-encoded `&amp;` collapses correctly to `&`; the second
+     * pass is a no-op when there's nothing left to decode.
+     */
+    private function decodeEntities(string $value): string
+    {
+        $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return html_entity_decode($decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
     protected function extractMetaTags(string $html): array
     {
         $meta = [];
 
         // Extract <title> tag
         if (preg_match('/<title[^>]*>([^<]+)<\/title>/i', $html, $matches)) {
-            $meta['title'] = trim(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+            $meta['title'] = trim($this->decodeEntities($matches[1]));
         }
 
         // Extract canonical URL
@@ -173,7 +192,7 @@ final readonly class MetadataService
         foreach ($matches as $match) {
             $name = strtolower($match[1]);
             if (in_array($name, ['description', 'keywords', 'author'], true)) {
-                $meta[$name] = html_entity_decode($match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $meta[$name] = $this->decodeEntities($match[2]);
             }
         }
 
@@ -182,7 +201,7 @@ final readonly class MetadataService
         foreach ($matches as $match) {
             $name = strtolower($match[2]);
             if (in_array($name, ['description', 'keywords', 'author'], true) && !isset($meta[$name])) {
-                $meta[$name] = html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $meta[$name] = $this->decodeEntities($match[1]);
             }
         }
 
@@ -191,7 +210,7 @@ final readonly class MetadataService
         foreach ($matches as $match) {
             $property = strtolower($match[1]);
             if (str_starts_with($property, 'og:')) {
-                $meta[$property] = html_entity_decode($match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $meta[$property] = $this->decodeEntities($match[2]);
             }
         }
 
@@ -200,7 +219,7 @@ final readonly class MetadataService
         foreach ($matches as $match) {
             $property = strtolower($match[2]);
             if (str_starts_with($property, 'og:') && !isset($meta[$property])) {
-                $meta[$property] = html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $meta[$property] = $this->decodeEntities($match[1]);
             }
         }
 
@@ -242,29 +261,104 @@ final readonly class MetadataService
     protected function formatYamlFrontMatter(array $data): string
     {
         $yaml = "---\n";
-
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                $yaml .= $key . ":\n";
-                foreach ($value as $item) {
-                    $yaml .= '  - ' . $this->escapeYamlValue($item) . "\n";
-                }
-            } else {
-                $yaml .= $key . ': ' . $this->escapeYamlValue($value) . "\n";
-            }
+            $yaml .= $this->renderYamlPair((string)$key, $value, 0);
         }
-
         $yaml .= "---\n\n";
 
         return $yaml;
     }
 
-    protected function escapeYamlValue(string $value): string
+    /**
+     * Render a single key/value pair as YAML. Supports nested lists (each
+     * list item can itself be a list of scalars or an associative array)
+     * so a listener that adds, e.g., `upcoming_dates: [{start, end, location}, ...]`
+     * doesn't crash the renderer.
+     *
+     * @param mixed $value
+     */
+    private function renderYamlPair(string $key, mixed $value, int $depth): string
     {
-        // If the value contains special characters, wrap in quotes
-        if (preg_match('/[:#{}\[\]&*?|>!\'\"%@`]/', $value) || str_contains($value, "\n")) {
-            return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $value) . '"';
+        $indent = str_repeat('  ', $depth);
+        if (!is_array($value)) {
+            return $indent . $key . ': ' . $this->escapeYamlValue($value) . "\n";
         }
-        return $value;
+        if ($value === []) {
+            return $indent . $key . ": []\n";
+        }
+        $yaml = $indent . $key . ":\n";
+        if (array_is_list($value)) {
+            foreach ($value as $item) {
+                $yaml .= $this->renderYamlListItem($item, $depth + 1);
+            }
+            return $yaml;
+        }
+        // Associative array — render as nested mapping.
+        foreach ($value as $childKey => $childValue) {
+            $yaml .= $this->renderYamlPair((string)$childKey, $childValue, $depth + 1);
+        }
+        return $yaml;
+    }
+
+    /**
+     * @param mixed $item
+     */
+    private function renderYamlListItem(mixed $item, int $depth): string
+    {
+        $indent = str_repeat('  ', $depth);
+        if (!is_array($item)) {
+            return $indent . '- ' . $this->escapeYamlValue($item) . "\n";
+        }
+        if ($item === []) {
+            return $indent . "- []\n";
+        }
+        if (array_is_list($item)) {
+            // List of lists — render the inner list under a dash-anchored block.
+            $yaml = $indent . "-\n";
+            foreach ($item as $sub) {
+                $yaml .= $this->renderYamlListItem($sub, $depth + 1);
+            }
+            return $yaml;
+        }
+        // Associative array as a list item — first pair shares the dash line,
+        // subsequent pairs are aligned to the same indent.
+        $yaml = '';
+        $first = true;
+        foreach ($item as $childKey => $childValue) {
+            if ($first) {
+                $first = false;
+                if (is_array($childValue)) {
+                    // Complex first value: dash on its own line, child indented.
+                    $yaml .= $indent . "-\n" . $this->renderYamlPair((string)$childKey, $childValue, $depth + 1);
+                } else {
+                    $yaml .= $indent . '- ' . (string)$childKey . ': ' . $this->escapeYamlValue($childValue) . "\n";
+                }
+                continue;
+            }
+            // Subsequent keys: indent matches the position after "- " (depth + 1).
+            $yaml .= $this->renderYamlPair((string)$childKey, $childValue, $depth + 1);
+        }
+        return $yaml;
+    }
+
+    /**
+     * Escape a scalar value for safe YAML emission. Accepts scalars (string,
+     * int, float, bool) and null so callers don't have to cast every numeric
+     * count or boolean flag they want to surface.
+     */
+    protected function escapeYamlValue(string|int|float|bool|null $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        $string = (string)$value;
+        // Quote when the value contains YAML-reserved characters or newlines.
+        if (preg_match('/[:#{}\[\]&*?|>!\'\"%@`]/', $string) || str_contains($string, "\n")) {
+            return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $string) . '"';
+        }
+        return $string;
     }
 }

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -12,7 +12,7 @@ namespace B13\AiBotsLoveMarkdown\Service;
  * of the License, or any later version.
  */
 
-use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use B13\AiBotsLoveMarkdown\Event\AfterFrontMatterForPageIsCreatedEvent;
 use Doctrine\DBAL\ParameterType;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,7 +30,7 @@ final readonly class MetadataService
      * Generate YAML front matter from HTML meta tags and page record.
      *
      * Meta tags take priority, page record is used as fallback.
-     * Dispatches {@see ModifyFrontMatterDataEvent} so listeners can add or
+     * Dispatches {@see AfterFrontMatterForPageIsCreatedEvent} so listeners can add or
      * modify entries before the array is rendered to YAML.
      */
     public function generateFrontMatter(
@@ -43,7 +43,7 @@ final readonly class MetadataService
         $frontMatter = $this->buildFrontMatterData($html, $pageRecord, $fallbackUrl);
 
         $event = $this->eventDispatcher->dispatch(
-            new ModifyFrontMatterDataEvent(
+            new AfterFrontMatterForPageIsCreatedEvent(
                 frontMatter: $frontMatter,
                 pageRecord: $pageRecord,
                 html: $html,

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -102,7 +102,7 @@ final readonly class MetadataService
         // SYS_LASTCHANGED is intentionally not surfaced as a separate
         // "lastUpdated" key — it's almost always identical to tstamp and just
         // adds noise. Listeners can add their own date keys via
-        // ModifyFrontMatterDataEvent when they need a domain-specific date.
+        // AfterFrontMatterForPageIsCreatedEvent when they need a domain-specific date.
         if (!empty($pageRecord['crdate'])) {
             $frontMatter['date'] = date('Y-m-d', (int)$pageRecord['crdate']);
         }
@@ -164,11 +164,26 @@ final readonly class MetadataService
      * which leaves us with `&amp;amp;` in the source HTML. A single decode
      * pass on a single-encoded `&amp;` collapses correctly to `&`; the second
      * pass is a no-op when there's nothing left to decode.
+     *
+     * Whitespace is collapsed afterwards so values whose source is a Fluid
+     * partial (where indentation and newlines leak into the meta content)
+     * don't end up as multi-line YAML strings.
      */
     private function decodeEntities(string $value): string
     {
         $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        return html_entity_decode($decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $decoded = html_entity_decode($decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return $this->normalizeWhitespace($decoded);
+    }
+
+    /**
+     * Collapses runs of whitespace (including newlines and tabs that leak in
+     * from Fluid-rendered meta tags) into a single space and trims.
+     * Preserves regular spaces between words.
+     */
+    private function normalizeWhitespace(string $value): string
+    {
+        return trim((string)preg_replace('/\s+/u', ' ', $value));
     }
 
     protected function extractMetaTags(string $html): array

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -12,20 +12,56 @@ namespace B13\AiBotsLoveMarkdown\Service;
  * of the License, or any later version.
  */
 
+use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
 use Doctrine\DBAL\ParameterType;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Frontend\Page\PageInformation;
 
 final readonly class MetadataService
 {
     public function __construct(
         protected ConnectionPool $connectionPool,
+        protected EventDispatcherInterface $eventDispatcher,
     ) {}
 
     /**
-     * Generate YAML front matter from HTML meta tags and page record
-     * Meta tags take priority, page record is used as fallback
+     * Generate YAML front matter from HTML meta tags and page record.
+     *
+     * Meta tags take priority, page record is used as fallback.
+     * Dispatches {@see ModifyFrontMatterDataEvent} so listeners can add or
+     * modify entries before the array is rendered to YAML.
      */
-    public function generateFrontMatter(string $html, array $pageRecord, string $fallbackUrl): string
+    public function generateFrontMatter(
+        string $html,
+        array $pageRecord,
+        string $fallbackUrl,
+        ?PageInformation $pageInformation = null,
+        ?ServerRequestInterface $request = null,
+    ): string {
+        $frontMatter = $this->buildFrontMatterData($html, $pageRecord, $fallbackUrl);
+
+        $event = $this->eventDispatcher->dispatch(
+            new ModifyFrontMatterDataEvent(
+                frontMatter: $frontMatter,
+                pageRecord: $pageRecord,
+                html: $html,
+                pageInformation: $pageInformation,
+                request: $request,
+            )
+        );
+
+        return $this->renderYaml($event->frontMatter);
+    }
+
+    /**
+     * Assemble the front-matter data array from HTML meta tags and the page record.
+     *
+     * Exposed as a separate step so integrators with their own rendering pipeline
+     * can grab the structured array directly.
+     */
+    public function buildFrontMatterData(string $html, array $pageRecord, string $fallbackUrl): array
     {
         // Extract metadata from HTML meta tags
         $metaTags = $this->extractMetaTags($html);
@@ -102,6 +138,14 @@ final readonly class MetadataService
             $frontMatter['locale'] = $metaTags['og:locale'];
         }
 
+        return $frontMatter;
+    }
+
+    /**
+     * Render a front-matter data array to a YAML front-matter block.
+     */
+    public function renderYaml(array $frontMatter): string
+    {
         return $this->formatYamlFrontMatter($frontMatter);
     }
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ visitors. Excludes can be **nested**.
 
 The default front matter is built from HTML meta tags and the page record. To
 add domain-specific keys (e.g. seminar data, product attributes, event dates),
-listen to the `ModifyFrontMatterDataEvent`. Listeners receive the assembled
+listen to the `AfterFrontMatterForPageIsCreatedEvent`. Listeners receive the assembled
 data array **before** it is rendered to YAML and may add, remove, or replace
 entries.
 
@@ -206,7 +206,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MySite\EventListener;
 
-use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use B13\AiBotsLoveMarkdown\Event\AfterFrontMatterForPageIsCreatedEvent;
 use MyVendor\MySite\Domain\Repository\SeminarRepository;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 
@@ -217,7 +217,7 @@ final readonly class AddSeminarFrontMatter
     ) {}
 
     #[AsEventListener]
-    public function __invoke(ModifyFrontMatterDataEvent $event): void
+    public function __invoke(AfterFrontMatterForPageIsCreatedEvent $event): void
     {
         $pageId = (int)($event->pageRecord['uid'] ?? 0);
         $seminar = $this->seminarRepository->findByDetailPageId($pageId);

--- a/README.md
+++ b/README.md
@@ -191,6 +191,60 @@ Both partials emit HTML comments (`<!-- markdown-start -->`,
 from regular page responses by a frontend middleware before they reach human
 visitors. Excludes can be **nested**.
 
+### Extending the YAML front matter
+
+The default front matter is built from HTML meta tags and the page record. To
+add domain-specific keys (e.g. seminar data, product attributes, event dates),
+listen to the `ModifyFrontMatterDataEvent`. Listeners receive the assembled
+data array **before** it is rendered to YAML and may add, remove, or replace
+entries.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MySite\EventListener;
+
+use B13\AiBotsLoveMarkdown\Event\ModifyFrontMatterDataEvent;
+use MyVendor\MySite\Domain\Repository\SeminarRepository;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+final readonly class AddSeminarFrontMatter
+{
+    public function __construct(
+        private SeminarRepository $seminarRepository,
+    ) {}
+
+    #[AsEventListener]
+    public function __invoke(ModifyFrontMatterDataEvent $event): void
+    {
+        $pageId = (int)($event->pageRecord['uid'] ?? 0);
+        $seminar = $this->seminarRepository->findByDetailPageId($pageId);
+        if ($seminar === null) {
+            return;
+        }
+
+        $event->frontMatter['seminar_title'] = $seminar->getTitle();
+        $event->frontMatter['seminar_instructor'] = $seminar->getInstructor()?->getDisplayName();
+        $event->frontMatter['seminar_price_eur'] = number_format($seminar->getPriceCents() / 100, 2, '.', '');
+        $event->frontMatter['seminar_dates'] = array_map(
+            static fn (\DateTimeImmutable $d) => $d->format('Y-m-d'),
+            $seminar->getDates(),
+        );
+    }
+}
+```
+
+The event also exposes `$html`, `$pageInformation`, and `$request` (each
+read-only) so listeners can resolve site, language, or routing information
+when needed. Array order is preserved in the rendered YAML, so you can
+prepend custom keys by recreating the array if order matters.
+
+If you need to bypass the YAML rendering entirely, the underlying methods
+`MetadataService::buildFrontMatterData()` and `MetadataService::renderYaml()`
+are public and can be used directly.
+
 ## License
 
 The extension is licensed under GPL v2+, same as the TYPO3 Core.

--- a/Tests/Unit/Service/MetadataServiceYamlRendererTest.php
+++ b/Tests/Unit/Service/MetadataServiceYamlRendererTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "ai_bots_love_markdown" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\AiBotsLoveMarkdown\Tests\Unit\Service;
+
+use B13\AiBotsLoveMarkdown\Service\MetadataService;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class MetadataServiceYamlRendererTest extends UnitTestCase
+{
+    private function service(): MetadataService
+    {
+        return new MetadataService(
+            $this->createMock(ConnectionPool::class),
+            $this->createMock(EventDispatcherInterface::class),
+        );
+    }
+
+    #[Test]
+    public function rendersFlatScalarFrontMatter(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'title' => 'Hello',
+            'modified' => '2026-05-16',
+        ]);
+
+        self::assertSame(
+            "---\ntitle: Hello\nmodified: 2026-05-16\n---\n\n",
+            $yaml,
+        );
+    }
+
+    #[Test]
+    public function rendersListOfScalars(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'keywords' => ['foo', 'bar'],
+        ]);
+
+        self::assertSame(
+            "---\nkeywords:\n  - foo\n  - bar\n---\n\n",
+            $yaml,
+        );
+    }
+
+    #[Test]
+    public function rendersListOfAssociativeArrays(): void
+    {
+        // upcoming_dates use case — each item is an associative array.
+        $yaml = $this->service()->renderYaml([
+            'upcoming_dates' => [
+                ['start' => '2026-09-15', 'end' => '2026-09-16', 'location' => 'TAE Esslingen'],
+                ['start' => '2027-03-12', 'end' => '2027-03-13', 'location' => 'Online'],
+            ],
+        ]);
+
+        $expected = "---\nupcoming_dates:\n"
+            . "  - start: 2026-09-15\n"
+            . "    end: 2026-09-16\n"
+            . "    location: TAE Esslingen\n"
+            . "  - start: 2027-03-12\n"
+            . "    end: 2027-03-13\n"
+            . "    location: Online\n"
+            . "---\n\n";
+        self::assertSame($expected, $yaml);
+    }
+
+    #[Test]
+    public function rendersNestedAssociativeMapping(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'next_event' => ['start' => '2026-09-15', 'location' => 'Esslingen'],
+        ]);
+
+        $expected = "---\nnext_event:\n"
+            . "  start: 2026-09-15\n"
+            . "  location: Esslingen\n"
+            . "---\n\n";
+        self::assertSame($expected, $yaml);
+    }
+
+    #[Test]
+    public function rendersIntegerCountWithoutThrowing(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'course_count' => 47,
+        ]);
+
+        self::assertSame("---\ncourse_count: 47\n---\n\n", $yaml);
+    }
+
+    #[Test]
+    public function rendersBooleanAndNullValues(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'flag' => true,
+            'optional' => null,
+        ]);
+
+        self::assertSame("---\nflag: true\noptional: null\n---\n\n", $yaml);
+    }
+
+    #[Test]
+    public function rendersEmptyListAsBracketPair(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'categories' => [],
+        ]);
+
+        self::assertSame("---\ncategories: []\n---\n\n", $yaml);
+    }
+
+    #[Test]
+    public function quotesValuesWithSpecialCharacters(): void
+    {
+        $yaml = $this->service()->renderYaml([
+            'title' => 'A: complicated [value]',
+        ]);
+
+        self::assertStringContainsString('title: "A: complicated [value]"', $yaml);
+    }
+}

--- a/Tests/Unit/Service/MetadataServiceYamlRendererTest.php
+++ b/Tests/Unit/Service/MetadataServiceYamlRendererTest.php
@@ -22,9 +22,15 @@ final class MetadataServiceYamlRendererTest extends UnitTestCase
 {
     private function service(): MetadataService
     {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        // Default behaviour: pass the event back through unchanged so listeners
+        // would be a no-op. Tests that need to assert on listener interaction
+        // can override this expectation locally.
+        $eventDispatcher->method('dispatch')->willReturnArgument(0);
+
         return new MetadataService(
             $this->createMock(ConnectionPool::class),
-            $this->createMock(EventDispatcherInterface::class),
+            $eventDispatcher,
         );
     }
 
@@ -130,5 +136,30 @@ final class MetadataServiceYamlRendererTest extends UnitTestCase
         ]);
 
         self::assertStringContainsString('title: "A: complicated [value]"', $yaml);
+    }
+
+    #[Test]
+    public function collapsesWhitespaceInMetaTagsFromFluidRenderedHtml(): void
+    {
+        // Simulates a Fluid-rendered meta description where indentation +
+        // newlines from the template have leaked into the content attribute.
+        $html = '<meta name="description" content="Hello world'
+            . "\n\t\t\t " . '&#9655;'
+            . "\n\t\t\t" . 'Second sentence." />'
+            . '<meta property="og:title" content="A &amp;amp; B" />';
+
+        $service = $this->service();
+        $yaml = $service->generateFrontMatter($html, [], 'https://example.com/');
+
+        // Description should be a single line, no tabs, no entity-encoded triangle.
+        self::assertStringContainsString(
+            'description: Hello world ▷ Second sentence.',
+            $yaml,
+        );
+        // og:title double-encoded should still decode to plain "&"; the value
+        // also gets quoted because "&" is a YAML special character.
+        self::assertStringContainsString('title: "A & B"', $yaml);
+        // No physical tab characters mid-value (whitespace was collapsed).
+        self::assertStringNotContainsString("\t", $yaml);
     }
 }


### PR DESCRIPTION
## Summary

Three small fixes to `MetadataService`'s YAML renderer that surfaced while
integrating the extension into a downstream sitepackage with a handful of
`ModifyFrontMatterDataEvent` listeners.

## Why

1. **`escapeYamlValue()` was strictly typed to `string`** — so as soon as a
   listener added a numeric / boolean / null value (e.g. \`course_count: 47\`),
   the renderer crashed with a TypeError. Now accepts \`string|int|float|bool|null\`.

2. **`formatYamlFrontMatter()` only handled one level of nesting** — a list
   of associative arrays (e.g. \`upcoming_dates: [{start, end, location}, …]\`)
   triggered the same TypeError because each list item was passed straight into
   `escapeYamlValue()`. The renderer is now properly recursive: list items can
   be scalars, nested lists, or associative arrays, and associative arrays
   render as YAML mappings.

3. **Entity decoding wasn't applied to page-record fallbacks** and ran only once
   — but some TYPO3 installations double-encode meta-tag content attributes
   (a `<title>` that already contains `&amp;` is re-escaped on the way into
   `<meta property=\"og:title\">` and ends up as `&amp;amp;` in the source HTML).
   The decode helper now runs twice (single-encoded values no-op on the second
   pass; double-encoded values collapse cleanly) and page-record fallbacks for
   title / description / author go through the helper.

4. **`SYS_LASTCHANGED` is no longer surfaced as a separate `lastUpdated` key**
   — it's almost always identical to `tstamp` (already exposed as `modified`)
   and just adds noise. Listeners can add their own date keys via
   `ModifyFrontMatterDataEvent` when a domain-specific date is meaningful.

## Changes

- `Classes/Service/MetadataService.php`
  - Extract `decodeEntities()` helper, apply consistently across meta-tag and
    page-record paths, run two decode passes.
  - Split `formatYamlFrontMatter()` into `renderYamlPair()` + `renderYamlListItem()`
    for proper recursion.
  - Widen `escapeYamlValue()` parameter type, handle bool / null / numeric.
  - Drop the `lastUpdated` front-matter key.
- `Tests/Unit/Service/MetadataServiceYamlRendererTest.php` (new)
  - 8 tests covering scalar tolerance, list of scalars, list of associative
    arrays, nested mapping, empty list, int / bool / null escape, special-char
    quoting.

## Test plan

- [x] `vendor/bin/phpunit Tests/Unit/` — 8/8 green on this branch
- [x] End-to-end verified live against TAE: an `upcoming_dates` listener
      emitting a list of associative arrays now renders cleanly, and
      `course_count: 47` no longer crashes the renderer.

## Stack

Built on top of #8 (ModifyFrontMatterDataEvent) because it uses the refactored
constructor signature (\`EventDispatcherInterface\` dependency) and the
\`renderYaml(array)\` public entry point. If #8 lands first, this PR rebases
trivially.