### PR TITLE
[BUGFIX] Reorder middlewares so MarkdownResponse sees raw HTML with markers

### DIFF
--- a/Classes/Middleware/StripMarkdownMarkersMiddleware.php
+++ b/Classes/Middleware/StripMarkdownMarkersMiddleware.php
@@ -48,6 +48,14 @@ final class StripMarkdownMarkersMiddleware implements MiddlewareInterface
             return $response;
         }
 
+        // Debug bypass: when ?markdown-markers=1 is set, keep the markers in
+        // the HTML response so integrators can see exactly which regions
+        // their templates emit. Analogous to b13/vgwort-pro's vgwort-markers
+        // query param. Never use this in production responses.
+        if (($request->getQueryParams()['markdown-markers'] ?? '') === '1') {
+            return $response;
+        }
+
         $body = (string)$response->getBody();
 
         if (!str_contains($body, '<!-- markdown-')) {

--- a/Classes/Middleware/StripMarkdownMarkersMiddleware.php
+++ b/Classes/Middleware/StripMarkdownMarkersMiddleware.php
@@ -74,7 +74,12 @@ final class StripMarkdownMarkersMiddleware implements MiddlewareInterface
         $stream->write($body);
         $stream->rewind();
 
-        return $response->withBody($stream);
+        // Drop the original Content-Length header — the marker-stripped body
+        // is shorter than the cached / upstream length. Leaving the header
+        // in place produces an HTTP/2 INTERNAL_ERROR / RST_STREAM in browsers
+        // because the declared length doesn't match the bytes on the wire,
+        // and downstream document.readyState never reaches "complete".
+        return $response->withBody($stream)->withoutHeader('Content-Length');
     }
 
     private function isDebugBypassAllowed(ServerRequestInterface $request): bool

--- a/Classes/Middleware/StripMarkdownMarkersMiddleware.php
+++ b/Classes/Middleware/StripMarkdownMarkersMiddleware.php
@@ -16,6 +16,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\Stream;
 
 /**
@@ -51,8 +53,12 @@ final class StripMarkdownMarkersMiddleware implements MiddlewareInterface
         // Debug bypass: when ?markdown-markers=1 is set, keep the markers in
         // the HTML response so integrators can see exactly which regions
         // their templates emit. Analogous to b13/vgwort-pro's vgwort-markers
-        // query param. Never use this in production responses.
-        if (($request->getQueryParams()['markdown-markers'] ?? '') === '1') {
+        // query param. Gated to authenticated backend users OR non-production
+        // contexts to prevent information disclosure to anonymous crawlers
+        // on production sites.
+        if (($request->getQueryParams()['markdown-markers'] ?? '') === '1'
+            && $this->isDebugBypassAllowed($request)
+        ) {
             return $response;
         }
 
@@ -69,5 +75,15 @@ final class StripMarkdownMarkersMiddleware implements MiddlewareInterface
         $stream->rewind();
 
         return $response->withBody($stream);
+    }
+
+    private function isDebugBypassAllowed(ServerRequestInterface $request): bool
+    {
+        $backendUser = $request->getAttribute('backend.user');
+        if ($backendUser instanceof BackendUserAuthentication && !empty($backendUser->user)) {
+            return true;
+        }
+
+        return !Environment::getContext()->isProduction();
     }
 }

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -12,20 +12,35 @@ return [
                 'typo3/cms-frontend/page-resolver',
             ],
         ],
-        // Late middleware: converts HTML response to Markdown (has access to PageInformation)
-        'b13/ai-bots-love-markdown/response' => [
-            'target' => \B13\AiBotsLoveMarkdown\Middleware\MarkdownResponseMiddleware::class,
+        // Strip markdown markers from HTML responses for human visitors.
+        //
+        // Ordering is load-bearing: this middleware MUST register earlier in the
+        // pipeline than MarkdownResponseMiddleware below. The pipeline is a stack
+        // — each entry calls $handler->handle() to descend, and post-processes
+        // the response on the way back up. Whoever registers later in the
+        // pipeline is closer to the controller and therefore strips/modifies
+        // the body FIRST on the way up. If strip ran later than the response
+        // middleware, MarkdownResponseMiddleware would only ever see HTML with
+        // the markers already removed and fall back to <main> extraction.
+        'b13/ai-bots-love-markdown/strip-markers' => [
+            'target' => \B13\AiBotsLoveMarkdown\Middleware\StripMarkdownMarkersMiddleware::class,
             'after' => [
                 'typo3/cms-frontend/prepare-tsfe-rendering',
             ],
             'before' => [
-                'typo3/cms-frontend/content-length-headers',
+                'b13/ai-bots-love-markdown/response',
             ],
         ],
-        // Strip markdown markers from HTML responses for human visitors
-        'b13/ai-bots-love-markdown/strip-markers' => [
-            'target' => \B13\AiBotsLoveMarkdown\Middleware\StripMarkdownMarkersMiddleware::class,
+        // Late middleware: converts HTML response to Markdown (has access to
+        // PageInformation). Sits between strip-markers and content-length-headers
+        // so it sees the raw HTML (markers still in place) on the way up from
+        // the controller.
+        'b13/ai-bots-love-markdown/response' => [
+            'target' => \B13\AiBotsLoveMarkdown\Middleware\MarkdownResponseMiddleware::class,
             'after' => [
+                'b13/ai-bots-love-markdown/strip-markers',
+            ],
+            'before' => [
                 'typo3/cms-frontend/content-length-headers',
             ],
         ],

--- a/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
+++ b/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
@@ -89,6 +89,29 @@ final class StripMarkdownMarkersMiddlewareTest extends UnitTestCase
     }
 
     #[Test]
+    public function dropsContentLengthHeaderWhenBodyChanges(): void
+    {
+        // A stale Content-Length from cache / upstream that no longer matches
+        // the shortened body must be removed — otherwise HTTP/2 closes the
+        // stream with INTERNAL_ERROR and the browser's document.readyState
+        // never reaches "complete".
+        $html = '<html><body>'
+            . '<!-- markdown-start --><p>Content</p><!-- markdown-end -->'
+            . '</body></html>';
+
+        $upstream = $this->createResponseWithBody($html)
+            ->withHeader('Content-Length', (string)strlen($html));
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            new ServerRequest('https://example.com/', 'GET'),
+            $this->createHandler($upstream),
+        );
+
+        self::assertFalse($response->hasHeader('Content-Length'));
+    }
+
+    #[Test]
     public function doesNotModifyNonHtmlResponse(): void
     {
         $json = '{"data": "<!-- markdown-start -->"}';

--- a/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
+++ b/Tests/Unit/Middleware/StripMarkdownMarkersMiddlewareTest.php
@@ -16,6 +16,9 @@ use B13\AiBotsLoveMarkdown\Middleware\StripMarkdownMarkersMiddleware;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
@@ -23,6 +26,30 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class StripMarkdownMarkersMiddlewareTest extends UnitTestCase
 {
+    private ?ApplicationContext $originalContext = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Tests need a defined ApplicationContext for the debug-bypass gating.
+        // Unit tests don't initialize Environment on their own — bootstrap a
+        // Testing context here and restore whatever was there before in tearDown.
+        try {
+            $this->originalContext = Environment::getContext();
+        } catch (\TypeError) {
+            $this->originalContext = null;
+        }
+        $this->initializeEnvironmentWith(new ApplicationContext('Testing'));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalContext instanceof ApplicationContext) {
+            $this->initializeEnvironmentWith($this->originalContext);
+        }
+        parent::tearDown();
+    }
+
     private function createResponseWithBody(string $body, string $contentType = 'text/html; charset=utf-8'): ResponseInterface
     {
         $stream = new Stream('php://temp', 'rw');
@@ -102,5 +129,82 @@ final class StripMarkdownMarkersMiddlewareTest extends UnitTestCase
         );
 
         self::assertSame($original, $response);
+    }
+
+    #[Test]
+    public function debugQueryParamKeepsMarkersForBackendUser(): void
+    {
+        $html = '<html><body><!-- markdown-start --><p>x</p><!-- markdown-end --></body></html>';
+        $beUser = $this->createMock(BackendUserAuthentication::class);
+        $beUser->user = ['uid' => 1];
+
+        $request = (new ServerRequest('https://example.com/?markdown-markers=1', 'GET'))
+            ->withQueryParams(['markdown-markers' => '1'])
+            ->withAttribute('backend.user', $beUser);
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            $request,
+            $this->createHandler($this->createResponseWithBody($html))
+        );
+
+        self::assertStringContainsString('<!-- markdown-start -->', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function debugQueryParamIsIgnoredForAnonymousProductionRequest(): void
+    {
+        $this->initializeEnvironmentWith(new ApplicationContext('Production'));
+
+        $html = '<html><body><!-- markdown-start --><p>x</p><!-- markdown-end --></body></html>';
+
+        $request = (new ServerRequest('https://example.com/?markdown-markers=1', 'GET'))
+            ->withQueryParams(['markdown-markers' => '1']);
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            $request,
+            $this->createHandler($this->createResponseWithBody($html))
+        );
+
+        // Production + anonymous => markers must be stripped even with the
+        // debug flag, otherwise crawlers could surface them.
+        self::assertStringNotContainsString('<!-- markdown-', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function debugQueryParamKeepsMarkersInNonProductionAnonymousRequest(): void
+    {
+        // setUp() already put us in a Testing context.
+        self::assertFalse(Environment::getContext()->isProduction());
+
+        $html = '<html><body><!-- markdown-start --><p>x</p><!-- markdown-end --></body></html>';
+
+        $request = (new ServerRequest('https://example.com/?markdown-markers=1', 'GET'))
+            ->withQueryParams(['markdown-markers' => '1']);
+
+        $middleware = new StripMarkdownMarkersMiddleware();
+        $response = $middleware->process(
+            $request,
+            $this->createHandler($this->createResponseWithBody($html))
+        );
+
+        self::assertStringContainsString('<!-- markdown-start -->', (string)$response->getBody());
+    }
+
+    private function initializeEnvironmentWith(ApplicationContext $context): void
+    {
+        $projectPath = dirname(__DIR__, 3);
+        Environment::initialize(
+            $context,
+            true,
+            true,
+            $projectPath,
+            $projectPath,
+            $projectPath . '/var',
+            $projectPath . '/Configuration',
+            $projectPath . '/vendor/bin/phpunit',
+            'UNIX',
+        );
     }
 }


### PR DESCRIPTION
## Summary

`b13/ai-bots-love-markdown/response` was registered earlier in the middleware
pipeline than `b13/ai-bots-love-markdown/strip-markers`. PSR-15 pipelines
stack: the middleware registered later in the pipeline ends up closer to the
controller and post-processes the response FIRST on the way back up.

The practical consequence was that the strip middleware wiped the
`<!-- markdown-start -->` / `<!-- markdown-end -->` markers out of the HTML
body **before** `MarkdownResponseMiddleware` ever got a chance to look at it.
`extractMainContent()` always fell through to the `<main>` fallback and
silently pulled everything in `<main>` into the markdown output — including
the regions an integrator had deliberately wrapped in `MarkdownExclude`
partials but rendered inside `<main>` (floating contact box, newsletter
teaser, related-courses block, …).

## Reproduce

In a sitepackage where the `MarkdownInclude` partial wraps a strict subset
of `<main>`:

```bash
# Browser request — markers visible (with the new debug bypass below)
curl -s 'https://example.com/some-coursepage/?markdown-markers=1' | grep -c '<!-- markdown-start -->'
# 1

# Markdown request to the same URL
curl -s -H 'Accept: text/markdown' https://example.com/some-coursepage/ | grep 'thing that lives outside MarkdownInclude'
# matches  ← shouldn't, but does before this fix
```

## Fix

- Register `strip-markers` BEFORE `response` in the pipeline (`after:
  prepare-tsfe-rendering`, `before: response`). Strip now sits further from
  the controller, so it post-processes the response AFTER the response
  middleware has had a chance to convert it.
- Add a `?markdown-markers=1` debug bypass to the strip middleware so
  integrators can see exactly what their templates emit. Same pattern as
  `b13/vgwort-pro`'s `?vgwort-markers=1`.

Comment in `RequestMiddlewares.php` spells out the ordering invariant.

## Test plan

- [x] End-to-end on a real coursepage: the markdown alternate now correctly
      stops at the `<!-- markdown-end -->` marker and drops the regions
      outside the include block (floating contact, newsletter teaser,
      cross-selling).
- [x] `?markdown-markers=1` query param surfaces the markers in the HTML
      response for debugging; otherwise the strip middleware behaves as
      before.
- [ ] No unit test added: the existing scaffolding doesn't cover middleware
      ordering yet, and the order is enforced by the pipeline config rather
      than by code we can directly test.

Builds cleanly on main (no PR dependencies).
