### PR TITLE
[BUGFIX] Capture PSR-7 chain and drop stale Content-Length

### DIFF
--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -20,7 +20,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Frontend\Page\PageInformation;
@@ -80,11 +79,16 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $body->write($markdown);
         $body->rewind();
 
-        $response
+        // PSR-7 messages are immutable — every withX() call returns a new instance,
+        // so the chain must be reassigned. Content-Length from the HTML response is
+        // dropped because the body length changed; the frontend's content-length
+        // middleware recalculates it. Without that, HTTP/2 clients close the stream.
+        $response = $response
             ->withBody($body)
             ->withStatus(200)
             ->withHeader('Content-Type', 'text/markdown; charset=utf-8')
-            ->withHeader('X-Robots-Tag', 'noindex');
+            ->withHeader('X-Robots-Tag', 'noindex')
+            ->withoutHeader('Content-Length');
 
         return $response;
     }


### PR DESCRIPTION
## Summary

Follow-up to #12 (`feat/cache-headers`) — two correctness fixes in `MarkdownResponseMiddleware`.

- **PSR-7 immutability**: the chain
  `$response->withBody(...)->withStatus(...)->withHeader(...)` returned new
  response instances that were discarded. `return $response` delivered the
  original HTML response unchanged — markdown body, status, content-type and
  `X-Robots-Tag` never reached the client. Reassign the chain.
- **Stale `Content-Length`**: the HTML response carries a `Content-Length` for
  the original HTML body. After swapping in the (typically much shorter)
  markdown payload that value is wrong. HTTP/2 clients abort the stream when
  promised more bytes than delivered, leaving the browser in
  `readyState: loading`. Drop the header so the frontend's content-length
  middleware recalculates it.
- Also removes the now-unused `use TYPO3\CMS\Core\Http\Response;` import.

Targeting `feat/cache-headers` so this can be folded into #12 before that PR
merges. If preferred, the commit can also be cherry-picked into a fresh PR
against `main` after merge.

## Test plan

- [ ] `curl -i -H "Accept: text/markdown" <page-url>` — verify response is
      `Content-Type: text/markdown; charset=utf-8`, has `X-Robots-Tag: noindex`,
      no `Content-Length` (or a recomputed correct one), body is markdown.
- [ ] Same request over HTTP/2 — verify browser/curl completes the stream cleanly.
- [ ] `curl -i <page-url>` (regular HTML) — verify the response still carries
      `Vary: Accept` and `Content-Length` is sane.