### PR TITLE
[FEATURE] Add cacheable site setting for markdown response

### DIFF
--- a/Classes/Middleware/MarkdownRequestMiddleware.php
+++ b/Classes/Middleware/MarkdownRequestMiddleware.php
@@ -30,20 +30,28 @@ use TYPO3\CMS\Core\Site\Entity\Site;
  */
 final readonly class MarkdownRequestMiddleware implements MiddlewareInterface
 {
-    public const MARKER_ATTRIBUTE = 'ai-bots-love-markdown.requested';
+    public const MARKDOWN_REQUESTED_ATTRIBUTE = 'ai-bots-love-markdown.requested';
+
+    /** @deprecated */
+    public const MARKER_ATTRIBUTE = self::MARKDOWN_REQUESTED_ATTRIBUTE;
+
+    public const CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE = 'ai-bots-love-markdown.contentNegotiationEnabled';
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (!$this->wantsMarkdown($request)) {
-            return $handler->handle($request);
-        }
-
         if (!$this->isEnabled($request)) {
             return $handler->handle($request);
         }
 
         // Mark the request for markdown conversion
-        $request = $request->withAttribute(self::MARKER_ATTRIBUTE, true);
+        $request = $request->withAttribute(self::CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE, true);
+
+        if (!$this->wantsMarkdown($request)) {
+            return $handler->handle($request);
+        }
+
+        // Mark the request for markdown conversion
+        $request = $request->withAttribute(self::MARKDOWN_REQUESTED_ATTRIBUTE, true);
 
         // Clean up the request: remove .md suffix and type parameter so normal page renders
         $request = $this->cleanRequest($request);

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -20,7 +20,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Frontend\Page\PageInformation;
@@ -80,11 +79,16 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $body->write($markdown);
         $body->rewind();
 
-        $response
+        // PSR-7 messages are immutable — every withX() call returns a new instance,
+        // so the chain must be reassigned. Content-Length from the HTML response is
+        // dropped because the body length changed; the frontend's content-length
+        // middleware recalculates it. Without that, HTTP/2 clients close the stream.
+        $response = $response
             ->withBody($body)
             ->withStatus(200)
             ->withHeader('Content-Type', 'text/markdown; charset=utf-8')
-            ->withHeader('X-Robots-Tag', 'noindex');
+            ->withHeader('X-Robots-Tag', 'noindex')
+            ->withoutHeader('Content-Length');
 
         return $response;
     }

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -90,6 +90,15 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
             ->withHeader('X-Robots-Tag', 'noindex')
             ->withoutHeader('Content-Length');
 
+        // Optional cache override: sites that need every markdown delivery to reach
+        // the origin (e.g. for AI-bot tracking) can opt out of CDN caching by
+        // setting `ai_bots_love_markdown.cacheable: false`. The default is `true`
+        // — TYPO3's page-level Cache-Control is preserved and the CDN may cache.
+        $site = $request->getAttribute('site');
+        if ($site instanceof Site && !(bool)$site->getSettings()->get('ai_bots_love_markdown.cacheable', true)) {
+            $response = $response->withHeader('Cache-Control', 'private, no-store');
+        }
+
         return $response;
     }
 

--- a/Classes/Middleware/MarkdownResponseMiddleware.php
+++ b/Classes/Middleware/MarkdownResponseMiddleware.php
@@ -45,17 +45,22 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // Check if the early middleware marked this request for markdown conversion
-        if (!$request->getAttribute(MarkdownRequestMiddleware::MARKER_ATTRIBUTE)) {
-            return $handler->handle($request);
-        }
-
-        // Let the normal page render
         $response = $handler->handle($request);
 
         // Only process HTML responses
         $contentType = $response->getHeaderLine('Content-Type');
         if (!str_contains($contentType, 'text/html')) {
+            return $response;
+        }
+
+        if (!$request->getAttribute(MarkdownRequestMiddleware::CONTENT_NEGOTIATON_ENABLED_ATTRIBUTE)) {
+            return $response;
+        }
+
+        $response = $response->withHeader('Vary', 'Accept');
+
+        // Check if the early middleware marked this request for markdown conversion
+        if (!$request->getAttribute(MarkdownRequestMiddleware::MARKDOWN_REQUESTED_ATTRIBUTE)) {
             return $response;
         }
 
@@ -75,14 +80,13 @@ final readonly class MarkdownResponseMiddleware implements MiddlewareInterface
         $body->write($markdown);
         $body->rewind();
 
-        return new Response(
-            $body,
-            200,
-            [
-                'Content-Type' => 'text/markdown; charset=utf-8',
-                'X-Robots-Tag' => 'noindex',
-            ]
-        );
+        $response
+            ->withBody($body)
+            ->withStatus(200)
+            ->withHeader('Content-Type', 'text/markdown; charset=utf-8')
+            ->withHeader('X-Robots-Tag', 'noindex');
+
+        return $response;
     }
 
     private function convertToMarkdown(ServerRequestInterface $request, string $html): string

--- a/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
+++ b/Configuration/Sets/ai_bots_love_markdown/settings.definitions.yaml
@@ -7,3 +7,7 @@ settings:
     type: bool
     default: true
     label: 'Add <link rel="alternate"> tag for Markdown discovery'
+  ai_bots_love_markdown.cacheable:
+    type: bool
+    default: true
+    label: 'Allow CDN/reverse-proxy caching of Markdown responses (disable to track every hit at the origin)'

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ dependencies:
 
 ### Site Settings
 
-The extension provides two settings that can be configured per site (both enabled by default):
+The extension provides the following settings that can be configured per site:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `ai_bots_love_markdown.enableContentNegotiation` | `true` | Enable content negotiation via `Accept: text/markdown` header |
 | `ai_bots_love_markdown.enableDiscoveryTag` | `true` | Add `<link rel="alternate">` tag to HTML pages for Markdown discovery |
+| `ai_bots_love_markdown.cacheable` | `true` | Allow CDN / reverse-proxy caching of Markdown responses. Disable to force every hit through to the origin — required when you want to count AI-bot deliveries accurately (e.g. via `b13/ai-bot-tracker`). When `false`, `Cache-Control: private, no-store` is set on Markdown responses |
 
 To override these settings, add them to your site's `settings.yaml`:
 
@@ -43,9 +44,24 @@ To override these settings, add them to your site's `settings.yaml`:
 ai_bots_love_markdown:
   enableContentNegotiation: true
   enableDiscoveryTag: false
+  cacheable: false
 ```
 
 Currently, the suffix `/ai-bots-love.md` is hardcoded on purpose.
+
+### Caching and content negotiation
+
+Markdown responses share the URL of the HTML page when `Accept: text/markdown` is
+used. To prevent reverse proxies from serving a cached HTML response to a Markdown
+requester (or vice versa), the middleware adds a `Vary: Accept` header to every
+response that goes through a site with content negotiation enabled — regardless
+of whether the current request asked for Markdown.
+
+By default (`cacheable: true`), TYPO3's page-level `Cache-Control` is preserved
+on the Markdown response, so the CDN may cache. If you need every Markdown
+delivery to reach the origin — typically to track bot consumption — set
+`cacheable: false` and the response is sent with `Cache-Control: private,
+no-store`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Adds the site setting `ai_bots_love_markdown.cacheable` (default `true`) to
control CDN / reverse-proxy caching of markdown responses.

- `true` (default): no behaviour change from #3. TYPO3's page-level
  `Cache-Control` flows through to the markdown response, so a CDN may cache
  the markdown the same way it caches the underlying HTML.
- `false`: the middleware overrides `Cache-Control` with `private, no-store`,
  forcing every markdown request through to the origin. Required when an
  `AfterMarkdownConversionEvent` listener (e.g. `b13/ai-bot-tracker`) needs to
  count every bot delivery — otherwise the tracker only sees the first hit
  per cached entry per edge location.

The `Vary: Accept` header from #3 keeps content-negotiation safe under either
setting — it prevents the CDN from serving a cached HTML response to a
markdown requester or vice versa.

## Relationship to other PRs

This branch is built on top of:
- #3 (`feat/cache-headers`) by @tmaroschik — adds `Vary: Accept` and preserves
  cache headers
- #13 (`fix/cache-headers-immutability`) — fixes a PSR-7 immutability bug and
  stale `Content-Length` after body swap in #3

While those merge, this PR's diff against `main` shows all three commits. Once
#3 (with #13 folded in) is merged, this PR's diff shrinks to the single
`cacheable`-toggle commit. Alternatively, if you'd rather skip the chain and
merge this PR alone, it stands on its own and supersedes #3 + #13.

## Test plan

- [ ] `Site.settings.ai_bots_love_markdown.cacheable: true` (default) →
      `curl -i -H "Accept: text/markdown" <page-url>` shows the page's existing
      `Cache-Control` (e.g. `max-age=86400`).
- [ ] Flip to `cacheable: false` → same request shows
      `Cache-Control: private, no-store`.
- [ ] Verify CDN bypass: when a CDN sits in front, the no-store response
      reaches the origin on every request (check origin logs / tracker).